### PR TITLE
feat: expose complete MQTTnet reactive APIs

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: 'Release level'
+        description: 'SemVer level to increment from the latest RTM tag or MinVer floor'
         required: true
         type: choice
         options:
@@ -33,6 +33,10 @@ permissions:
   contents: write
   id-token: write
   packages: read
+
+concurrency:
+  group: builddeploy-release
+  cancel-in-progress: false
 
 env:
   configuration: Release
@@ -91,18 +95,29 @@ jobs:
               ;;
           esac
 
+          if ! [[ "$MINIMUM_MAJOR_MINOR" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::minMajorMinorVersion must use Major.Minor format (got '$MINIMUM_MAJOR_MINOR')."
+            exit 1
+          fi
+
           FLOOR="${MINIMUM_MAJOR_MINOR}.0"
           LAST="$(
-            git tag --list "${TAG_PREFIX}[0-9]*.[0-9]*.[0-9]*" \
-              | grep -Ev -- '-' \
+            git tag --merged HEAD --list "${TAG_PREFIX}*" \
+              | sed -nE "s/^${TAG_PREFIX}([0-9]+)\.([0-9]+)\.([0-9]+)$/\1.\2.\3/p" \
               | sort -V \
-              | tail -1 \
-              | sed "s/^${TAG_PREFIX}//" || true
+              | tail -1 || true
           )"
 
-          BASELINE="${LAST:-0.0.0}"
+          # MinVerMinimumMajorMinor is the initial version baseline, not a
+          # post-increment clamp. Apply it before the requested SemVer bump.
+          BASELINE="$FLOOR"
           if [ -z "$LAST" ]; then
-            echo "No RTM tag (${TAG_PREFIX}X.Y.Z) found; the next version will be clamped to the MinVer floor ${FLOOR}."
+            echo "No reachable RTM tag (${TAG_PREFIX}X.Y.Z) found; using the MinVer floor ${TAG_PREFIX}${FLOOR} as the release baseline."
+          else
+            BASELINE="$(printf '%s\n%s\n' "$FLOOR" "$LAST" | sort -V | tail -1)"
+            if [ "$BASELINE" != "$LAST" ]; then
+              echo "Latest reachable RTM tag ${TAG_PREFIX}${LAST} is below the MinVer floor; using ${TAG_PREFIX}${FLOOR} as the release baseline."
+            fi
           fi
 
           IFS=. read -r MAJOR MINOR PATCH <<< "$BASELINE"
@@ -111,8 +126,6 @@ jobs:
             minor) CORE="${MAJOR}.$((MINOR + 1)).0" ;;
             patch) CORE="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
           esac
-
-          CORE="$(printf '%s\n%s\n' "$FLOOR" "$CORE" | sort -V | tail -1)"
 
           if [ -n "$PRE_RELEASE_ID" ]; then
             MAXN=0
@@ -150,10 +163,15 @@ jobs:
             echo "prerelease=${PRERELEASE}"
           } >> "$GITHUB_OUTPUT"
 
-          {
-            echo "MINVERVERSIONOVERRIDE=${VERSION}"
-            echo "MinVerVersionOverride=${VERSION}"
-          } >> "$GITHUB_ENV"
+      - name: Stage local release tag for MinVer
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release-version.outputs.tag }}
+          SOURCE_SHA: ${{ steps.sourcesha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git tag "$RELEASE_TAG" "$SOURCE_SHA"
+          echo "Staged local tag ${RELEASE_TAG} at ${SOURCE_SHA} for MinVer validation."
 
       - name: Resolve release tag
         id: tagname
@@ -167,12 +185,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
-            11.0.x
-          dotnet-quality: 'preview'
+          global-json-file: global.json
           cache: true
           cache-dependency-path: |
             **/Directory.Packages.props
@@ -188,15 +201,57 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nugetv3-
 
+      - name: Validate release tag with pinned MinVer
+        id: minver-validate
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.release-version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          dotnet restore src/MQTTnet.Rx.Client/MQTTnet.Rx.Client.csproj
+          MINVER_VERSION="$(
+            dotnet msbuild src/MQTTnet.Rx.Client/MQTTnet.Rx.Client.csproj \
+              -target:MinVer \
+              -getProperty:MinVerVersion \
+              -verbosity:quiet \
+              | tr -d '\r' \
+              | tail -1
+          )"
+
+          if [ "$MINVER_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release resolver selected ${EXPECTED_VERSION}, but the repository-pinned MinVer package resolved ${MINVER_VERSION}."
+            exit 1
+          fi
+
+          echo "version=${MINVER_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Pinned MinVer validated local release tag v${MINVER_VERSION}."
+
       - name: Stamp version with MinVer
         id: minver
         uses: reactiveui/actions-common/.github/actions/minver@328a9bc8c0403e44969e5283389622094ceddd16
         with:
           tag-prefix: v
           minimum-major-minor: ${{ env.minMajorMinorVersion }}
-          auto-increment: minor
+          auto-increment: ${{ inputs.bump }}
           default-pre-release-identifiers: alpha.0
-          version-override: ${{ steps.release-version.outputs.version }}
+          version-override: ${{ steps.minver-validate.outputs.version }}
+
+      - name: Verify MinVer release version
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.release-version.outputs.version }}
+          MINVER_SEMVER2: ${{ steps.minver.outputs.SemVer2 }}
+          MINVER_PACKAGE_VERSION: ${{ steps.minver.outputs.NuGetPackageVersion }}
+        run: |
+          set -euo pipefail
+
+          if [ "$MINVER_SEMVER2" != "$EXPECTED_VERSION" ] || [ "$MINVER_PACKAGE_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release resolver selected ${EXPECTED_VERSION}, but MinVer returned SemVer2=${MINVER_SEMVER2} and NuGetPackageVersion=${MINVER_PACKAGE_VERSION}."
+            exit 1
+          fi
+
+          echo "Verified requested ${{ inputs.bump }} release version: ${EXPECTED_VERSION}"
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,6 +42,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Non-release builds use minor auto-increment. BuildDeploy passes the selected
+         Major/Minor/Patch increment and an asserted MinVerVersionOverride. -->
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
     <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerTagPrefix>v</MinVerTagPrefix>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.3.3" />
     <PackageVersion Include="MQTTnet" Version="5.2.0.1603" />
+    <PackageVersion Include="MQTTnet.AspNetCore" Version="5.2.0.1603" />
     <PackageVersion Include="MQTTnet.Server" Version="5.2.0.1603" />
     <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build](https://github.com/ChrisPulman/MQTTnet.Rx/actions/workflows/BuildOnly.yml/badge.svg)](https://github.com/ChrisPulman/MQTTnet.Rx/actions/workflows/BuildOnly.yml)
 [![MQTTnet.Rx.Client](https://img.shields.io/nuget/v/MQTTnet.Rx.Client.svg?style=flat-square&label=client)](https://www.nuget.org/packages/MQTTnet.Rx.Client)
 [![MQTTnet.Rx.Server](https://img.shields.io/nuget/v/MQTTnet.Rx.Server.svg?style=flat-square&label=server)](https://www.nuget.org/packages/MQTTnet.Rx.Server)
+[![MQTTnet.Rx.AspNetCore](https://img.shields.io/nuget/v/MQTTnet.Rx.AspNetCore.svg?style=flat-square&label=aspnetcore)](https://www.nuget.org/packages/MQTTnet.Rx.AspNetCore)
 
 <p align="left">
   <a href="https://github.com/ChrisPulman/MQTTnet.Rx">
@@ -21,6 +22,7 @@ The package family provides:
 - topic filtering, named topic-value extraction, JSON conversion, and payload helpers;
 - low-allocation pooled-payload, batching, throttling, sampling, and back-pressure helpers;
 - TLS, WebSocket, Azure IoT Hub/Event Grid, session, connection, and Last Will helpers;
+- fluent ASP.NET Core dependency-injection, endpoint, connection, hosted-server, and reactive connection APIs;
 - MQTT bridges for Allen-Bradley, Mitsubishi, Modbus, Omron, Siemens S7, serial ports, and TwinCAT.
 
 MQTTnet 5 removed `ManagedClient`. Use the `IResilientMqttClient` implementation supplied by `MQTTnet.Rx.Client` when an application needs automatic reconnection and an outbound queue.
@@ -36,10 +38,12 @@ MQTTnet 5 removed `ManagedClient`. Use the `IResilientMqttClient` implementation
 - [Connection configuration and Last Will](#connection-configuration-and-last-will)
 - [Low-allocation APIs](#low-allocation-apis)
 - [MQTT server](#mqtt-server)
+- [ASP.NET Core hosting](#aspnet-core-hosting)
 - [Industrial bridges](#industrial-bridges)
 - [Complete public API](#complete-public-api)
   - [`MQTTnet.Rx.Client`](#mqttnetrxclient-api)
   - [`MQTTnet.Rx.Server`](#mqttnetrxserver-api)
+  - [`MQTTnet.Rx.AspNetCore`](#mqttnetrxaspnetcore-api)
   - [Industrial packages](#industrial-package-api)
 - [Building the repository](#building-the-repository)
 - [Contributing](#contributing)
@@ -55,6 +59,7 @@ Choose one column for an application. A `.Reactive` package compiles the same so
 | --- | --- | --- | --- | --- |
 | MQTT client, resilience, payloads, topics | `MQTTnet.Rx.Client` | `MQTTnet.Rx.Client.Reactive` | `MQTTnet.Rx.Client` | `MQTTnet.Rx.Client.Reactive` |
 | MQTT broker/server | `MQTTnet.Rx.Server` | `MQTTnet.Rx.Server.Reactive` | `MQTTnet.Rx.Server` | `MQTTnet.Rx.Server.Reactive` |
+| ASP.NET Core hosting | `MQTTnet.Rx.AspNetCore` | `MQTTnet.Rx.AspNetCore.Reactive` | `MQTTnet.Rx.AspNetCore` | `MQTTnet.Rx.AspNetCore.Reactive` |
 | Allen-Bradley | `MQTTnet.Rx.ABPlc` | `MQTTnet.Rx.ABPlc.Reactive` | `MQTTnet.Rx.ABPlc` | `MQTTnet.Rx.ABPlc.Reactive` |
 | Mitsubishi | `MQTTnet.Rx.Mitsubishi` | `MQTTnet.Rx.Mitsubishi.Reactive` | `MQTTnet.Rx.Mitsubishi` | `MQTTnet.Rx.Mitsubishi.Reactive` |
 | Modbus | `MQTTnet.Rx.Modbus` | `MQTTnet.Rx.Modbus.Reactive` | `MQTTnet.Rx.Modbus` | `MQTTnet.Rx.Modbus.Reactive` |
@@ -69,6 +74,8 @@ All packages target .NET 8, .NET 9, .NET 10, and .NET 11. TwinCAT targets the Wi
 
 Industrial packages bring in the matching `IoT-Driver.*` package and `MQTTnet.Rx.Client` transitively. Their `.Reactive` siblings bring in the matching `IoT-Driver.*.Reactive` and client `.Reactive` packages.
 
+The ASP.NET Core packages bring in the matching `MQTTnet.Rx.Server` family transitively. Import both the ASP.NET Core and Server namespace when configuring the base `MqttServer` supplied to `UseMqttServer` callbacks.
+
 ### Lean or `.Reactive`?
 
 Both families use BCL `System.IObservable<T>`. The differences are the implementation package and the types used for completion values and scheduling:
@@ -82,6 +89,8 @@ Both families use BCL `System.IObservable<T>`. The differences are the implement
 | Grouped sequence | `MQTTnet.Rx.Client.Linq.IGroupedObservable<TKey,T>` | `System.Reactive.Linq.IGroupedObservable<TKey,T>` |
 
 Use the lean package in a Primitives-first application. Use `.Reactive` in an application already based on System.Reactive. Most examples below use the lean family; for `.Reactive`, change the package and the `MQTTnet.Rx.*` namespace to its `.Reactive` counterpart, then import System.Reactive operators as usual.
+
+Industrial `.Reactive` packages also use the matching reactive driver namespace: `IoT.Driver.ABPlcRx.Reactive`, `IoT.Driver.MitsubishiRx.Reactive`, `IoT.Driver.ModbusRx.Reactive`, `IoT.Driver.OmronPlcRx.Reactive`, `IoT.Driver.S7PlcRx.Reactive`, `IoT.Driver.Serial.Reactive`, or `IoT.Driver.TwinCATRx.Reactive`. Keep `IoT.Driver.Core` imports unchanged.
 
 This is the System.Reactive counterpart of the basic connected-client pipeline:
 
@@ -122,6 +131,7 @@ Install the smallest top-level package that supplies the required feature. NuGet
 ```bash
 dotnet add package MQTTnet.Rx.Client
 dotnet add package MQTTnet.Rx.Server
+dotnet add package MQTTnet.Rx.AspNetCore
 
 dotnet add package MQTTnet.Rx.ABPlc
 dotnet add package MQTTnet.Rx.Mitsubishi
@@ -136,7 +146,9 @@ For a System.Reactive application, install the corresponding package from the `.
 
 ```bash
 dotnet add package MQTTnet.Rx.Client.Reactive
+dotnet add package MQTTnet.Rx.AspNetCore.Reactive
 dotnet add package MQTTnet.Rx.Modbus.Reactive
+dotnet add package MQTTnet.SerialPort.Reactive
 dotnet add package MQTTnet.TwinCATRx.Reactive
 ```
 
@@ -262,7 +274,7 @@ await using var subscription = await messages.SubscribeAsync(
 
 ### Single MQTT operations
 
-`ReactiveClientOperationsExtensions` supplies fluent operations on `IObservable<IMqttClient>` and `IObservableAsync<IMqttClient>`. `ReactiveClientOperations` exposes the same overloads as static forwarding methods when extension syntax is inconvenient.
+`ReactiveClientOperationsExtensions` supplies fluent operations on `IObservable<IMqttClient>` and `IObservableAsync<IMqttClient>`. `ReactiveClientOperations` exposes the same overloads as static forwarding methods when extension syntax is inconvenient. A directly owned `IMqttClient` also has paired ordinary/async-observable methods through `MqttClientOperationExtensions`: `Connect`/`ObserveConnect`, `Disconnect`/`ObserveDisconnect`, `Ping`/`ObservePing`, `Publish`/`ObservePublish`, `Reconnect`/`ObserveReconnect`, enhanced-authentication exchange, subscribe, try-disconnect, try-ping, and unsubscribe. Builder callbacks preserve fluent configuration without hiding the complete MQTTnet options objects.
 
 ```csharp
 using MQTTnet;
@@ -317,7 +329,49 @@ using var disconnect = clients
     .Subscribe();
 ```
 
-`Reconnect()` reconnects with the underlying client's previous options. `PublishMany` accepts an observable (or async-observable) of complete `MqttApplicationMessage` values and emits one publish result per message.
+`Reconnect()` reconnects with the underlying client's previous options. `PublishMany` accepts an observable (or async-observable) of complete `MqttApplicationMessage` values and emits one publish result per message. `Properties()`, `PropertySnapshots()`/`ObservePropertySnapshots()`, `IsConnectedValue()`/`ObserveIsConnected()`, and `OptionsSnapshot()`/`ObserveOptionsSnapshot()` expose every public raw-client property. `WithAutoReconnect` is available for async-observable client sequences with configurable delay and retry count.
+
+For a caller-owned `IMqttClient`, each direct operation is cold: constructing the observable does no network work, and subscribing performs exactly one MQTT operation. Complete MQTTnet options objects and fluent builder callbacks are both supported.
+
+| Operation family | Ordinary observable | Async-observable | Result |
+| --- | --- | --- | --- |
+| connect | `Connect(options/configure)` | `ObserveConnect(options/configure)` | `MqttClientConnectResult` |
+| disconnect | `Disconnect(options/configure)` | `ObserveDisconnect(options/configure)` | completion value |
+| ping / safe ping | `Ping()`, `TryPing()` | `ObservePing()`, `ObserveTryPing()` | completion value / `bool` |
+| publish | `Publish(message/configure)` | `ObservePublish(message/configure)` | `MqttClientPublishResult` |
+| binary / sequence / string publish | `PublishBinary`, `PublishSequence`, `PublishString` | corresponding `Observe...` method | `MqttClientPublishResult` |
+| reconnect | `Reconnect()` | `ObserveReconnect()` | completion value |
+| enhanced authentication | `SendEnhancedAuthenticationExchangeData` | `ObserveSendEnhancedAuthenticationExchangeData` | completion value |
+| subscribe / unsubscribe | `Subscribe`, `Unsubscribe` | `ObserveSubscribe`, `ObserveUnsubscribe` | MQTTnet result object |
+| safe disconnect | `TryDisconnect` | `ObserveTryDisconnect` | `bool` |
+
+```csharp
+using System.Buffers;
+using MQTTnet;
+using MQTTnet.Protocol;
+using MQTTnet.Rx.Client;
+using ReactiveUI.Primitives;
+
+var factory = new MqttClientFactory();
+using var client = factory.CreateMqttClient();
+
+IObservable<MqttClientConnectResult> connect = client.Connect(options => options
+    .WithTcpServer("localhost", 1883)
+    .WithClientId("direct-client"));
+
+IObservable<MqttClientPublishResult> publish = client.PublishSequence(
+    "telemetry/frame",
+    new ReadOnlySequence<byte>(new byte[] { 0x01, 0x02, 0x03 }),
+    MqttQualityOfServiceLevel.AtLeastOnce,
+    retain: false);
+
+using var state = client.PropertySnapshots().Subscribe(snapshot =>
+    Console.WriteLine($"Connected={snapshot.IsConnected}; options={snapshot.Options?.ClientId}"));
+
+// Subscribing starts the operation. Compose connect and publish with the
+// application's preferred reactive operators when strict ordering is required.
+using var connection = connect.Subscribe(result => Console.WriteLine(result.ResultCode));
+```
 
 ### Raw client event streams
 
@@ -329,7 +383,7 @@ An emitted `IMqttClient` exposes synchronous and asynchronous bridges for all cl
 | `Connected()` | `ObserveConnected()` | `MqttClientConnectedEventArgs` |
 | `Connecting()` | `ObserveConnecting()` | `MqttClientConnectingEventArgs` |
 | `Disconnected()` | `ObserveDisconnected()` | `MqttClientDisconnectedEventArgs` |
-| `InspectPackage()` | `ObserveInspectPackage()` | `InspectMqttPacketEventArgs` |
+| `InspectPacket()` | `ObserveInspectPacket()` | `InspectMqttPacketEventArgs` |
 
 ```csharp
 using MQTTnet.Rx.Client;
@@ -343,7 +397,7 @@ using var events = clients.Subscribe(client =>
     using var connected = client.Connected().Subscribe(_ => Console.WriteLine("Connected"));
     using var disconnected = client.Disconnected().Subscribe(
         value => Console.WriteLine(value.Reason));
-    using var packets = client.InspectPackage().Subscribe(
+    using var packets = client.InspectPacket().Subscribe(
         value => Console.WriteLine($"{value.Direction}: {value.Packet}"));
 
     Console.ReadLine(); // Keeps the nested subscriptions alive for this sample.
@@ -477,6 +531,38 @@ Coordinate file access if more than one process may use the same path. Productio
 - subscription synchronization: `SubscribeAsync(IEnumerable<MqttTopicFilter>)` and `UnsubscribeAsync(IEnumerable<string>)`;
 - ordinary .NET events, `IObservable<T>` properties, `IObservableAsync<T>` properties, and awaited handler registration methods.
 
+Every direct task operation also has a cold ordinary/async-observable pair: `Enqueue`/`ObserveEnqueue`, `Ping`/`ObservePing`, `Start`/`ObserveStart`, `Stop`/`ObserveStop`, `Subscribe`/`ObserveSubscribe`, and `Unsubscribe`/`ObserveUnsubscribe`. `Start` accepts either `ResilientMqttClientOptions` or an `Action<ResilientMqttClientOptionsBuilder>`; `Stop` accepts an optional clean-disconnect flag. `Properties()` snapshots `InternalClient`, `IsConnected`, `IsStarted`, `Options`, and `PendingApplicationMessagesCount`, while `Property`/`ObserveProperty` select arbitrary state.
+
+```csharp
+using MQTTnet;
+using MQTTnet.Protocol;
+using MQTTnet.Rx.Client;
+using ReactiveUI.Primitives;
+
+var factory = new MqttClientFactory();
+using var client = ResilientMqttClientFactory.Create(
+    factory.CreateMqttClient(),
+    factory.DefaultLogger);
+
+using var state = client.PropertySnapshots().Subscribe(snapshot =>
+    Console.WriteLine($"Started={snapshot.IsStarted}; queued={snapshot.PendingApplicationMessagesCount}"));
+
+var start = client.Start(options => options.WithClientOptions(mqtt => mqtt
+    .WithTcpServer("localhost", 1883)
+    .WithClientId("direct-resilient")));
+
+var enqueue = client.Enqueue(new MqttApplicationMessageBuilder()
+    .WithTopic("telemetry/device-01")
+    .WithPayload("42")
+    .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.AtLeastOnce)
+    .Build());
+
+using var lifetime = start.Subscribe(_ => Console.WriteLine("Resilient client started"));
+// Subscribe to enqueue after the start operation completes, or compose both
+// operations in the application's pipeline. ObserveStart/ObserveEnqueue provide
+// cancellation-aware async-observable equivalents.
+```
+
 | Event category | .NET event | `IObservable<T>` | `IObservableAsync<T>` / helper |
 | --- | --- | --- | --- |
 | message processed | `ApplicationMessageProcessedEvent` | `ApplicationMessageProcessed` | `ApplicationMessageProcessedAsyncObservable` / `ObserveApplicationMessageProcessed()` |
@@ -487,7 +573,7 @@ Coordinate file access if more than one process may use the same path. Productio
 | state changed | `ConnectionStateChangedEvent` | `ConnectionStateChanged` | `ConnectionStateChangedAsyncObservable` / `ObserveConnectionStateChanged()` |
 | disconnected | `DisconnectedEvent` | `Disconnected` | `DisconnectedAsyncObservable` / `ObserveDisconnected()` |
 | synchronization failed | `SynchronizingSubscriptionsFailedEvent` | `SynchronizingSubscriptionsFailed` | `SynchronizingSubscriptionsFailedAsyncObservable` / `ObserveSynchronizingSubscriptionsFailed()` |
-| subscriptions changed | `SubscriptionsChangedEvent` | — | `ObserveSubscriptionsChanged()` |
+| subscriptions changed | `SubscriptionsChangedEvent` | `SubscriptionsChanged()` | `ObserveSubscriptionsChanged()` |
 
 Each `Register...Handler` method accepts `Func<TEventArgs, CancellationToken, ValueTask>` and returns an `IDisposable` registration.
 
@@ -703,6 +789,26 @@ using var lifetime = clients.Subscribe(
     error => Console.Error.WriteLine($"Reconnect limit reached: {error}"));
 ```
 
+The same policy is available for `IObservableAsync<IMqttClient>` and preserves cancellation through reconnect delays and attempts:
+
+```csharp
+using MQTTnet.Rx.Client;
+using ReactiveUI.Primitives.Async;
+
+using var cancellation = new CancellationTokenSource();
+var clients = Create.MqttClientSignal()
+    .WithClientOptions(options => options.WithTcpServer("localhost", 1883))
+    .WithAutoReconnect(TimeSpan.FromSeconds(5), maxReconnectAttempts: 10);
+
+await using var lifetime = await clients.SubscribeAsync(
+    (client, _) =>
+    {
+        Console.WriteLine($"Connected={client.IsConnected}");
+        return ValueTask.CompletedTask;
+    },
+    cancellation.Token);
+```
+
 This helper does not add an outbound queue. Use the resilient client when queued delivery or subscription synchronization is required.
 
 ## Low-allocation APIs
@@ -852,19 +958,73 @@ using var broker = servers.Subscribe(session =>
 
 `IMqttRetainedMessageModel` and `MqttRetainedMessageModel` round-trip MQTT retained messages. Their public contract includes `Topic`, `Payload`, `QualityOfServiceLevel`, `ContentType`, `ResponseTopic`, `CorrelationData`, `PayloadFormatIndicator`, and `UserProperties`, plus `Create(MqttApplicationMessage)` and `ToApplicationMessage()`.
 
+### Fluent server operations, properties, and configuration
+
+Every task-returning `MqttServer` operation has an ordinary observable and an async-observable form. This includes start/stop, client disconnect and broker-side subscribe/unsubscribe, retained-message query/update/delete, client/session queries, and injected application messages. The injection pair is named `InjectApplicationMessageOperation`/`ObserveInjectApplicationMessage` because MQTTnet already owns the instance name `InjectApplicationMessage`.
+
+For MQTTnet methods that do not accept a cancellation token, cancelling an async-observable subscription stops waiting for and emitting the result; it cannot cancel broker work already running inside MQTTnet. Injected-message and enhanced-authentication operations pass cancellation into MQTTnet directly.
+
+`Create.MqttServer(...)` emits an already-started, reference-count-owned server. Do not call the direct `Start` or `Stop` wrappers on that emitted instance; dispose the factory subscription/session and let it own the lifecycle. Use `Start`/`ObserveStart` and `Stop`/`ObserveStop` only with an independently created `MqttServer`.
+
+`Properties()` captures `AcceptNewConnections`, `IsStarted`, and a safe copy of `ServerSessionItems`. Generic `Property`/`ObserveProperty`, snapshot streams, `AcceptNewConnectionsValue`/`ObserveAcceptNewConnections`, session-item snapshots, and distinct lifecycle streams expose all public server state. `WithAcceptNewConnections`, server-session item methods, and `ConfigureServer` preserve the receiver for fluent composition; the same configuration method is available on ordinary and async-observable server sequences. `ConfigureOptions` on MQTTnet's server, stop, and client-disconnect builders provides receiver-preserving access to the complete options objects.
+
+Values returned by `GetClients` and `GetSessions` remain reactive. The query result types are `IList<MqttClientStatus>`, `MqttApplicationMessage`, `IList<MqttApplicationMessage>`, `MqttSessionStatus`, and `IList<MqttSessionStatus>`. `MqttClientStatus` exposes complete property snapshots plus disconnect/`ObserveDisconnect`, `ResetStatisticsOperation`/`ObserveResetStatistics`, and `WithSession`. `MqttSessionStatus` exposes complete snapshots, fluent session-item changes, and paired queue-clear, delete, deliver, and enqueue operations. `TryEnqueueApplicationMessage` returns `MqttSessionEnqueueResult`, retaining both the queue decision and optional `InjectMqttApplicationMessageResult`. Connection validation exposes `ExchangeEnhancedAuthentication`/`ObserveExchangeEnhancedAuthentication` and returns `ExchangeEnhancedAuthenticationResult`.
+
+| Configuration/operation | Supported forms |
+| --- | --- |
+| disconnect client | `DisconnectClient` / `ObserveDisconnectClient` with options or builder callback |
+| stop independently owned server | parameterless, `MqttServerStopOptions`, or builder callback |
+| broker-side subscribe | topic-filter collection or `MqttTopicFilterBuilder` callback |
+| broker-side unsubscribe | client ID plus topic-name collection |
+| options mutation | `ConfigureOptions` on server, stop, and client-disconnect builders |
+| server sequence configuration | `ConfigureServer` on `IObservable<MqttServer>` and `IObservableAsync<MqttServer>` |
+
+```csharp
+using MQTTnet;
+using MQTTnet.Rx.Server;
+using ReactiveUI.Primitives;
+
+using var broker = Create.MqttServer(builder => builder.Build()).Subscribe(session =>
+{
+    session.Server
+        .WithAcceptNewConnections(true)
+        .WithServerSessionItem("environment", "production");
+
+    session.Disposable.Add(session.Server.IsStartedChanges().Subscribe(Console.WriteLine));
+    session.Disposable.Add(session.Server.GetClients().Subscribe(clients =>
+    {
+        foreach (var client in clients)
+        {
+            var clientState = client.Properties();
+            var sessionState = client.Session.Properties();
+            Console.WriteLine($"{clientState.Id}: {clientState.BytesReceived} bytes; " +
+                              $"queued={sessionState.PendingApplicationMessagesCount}");
+        }
+    }));
+    session.Disposable.Add(session.Server
+        .UpdateRetainedMessage(new MqttApplicationMessageBuilder()
+            .WithTopic("status/broker")
+            .WithPayload("online")
+            .WithRetainFlag()
+            .Build())
+        .Subscribe());
+});
+```
+
 ### Complete server event list
 
-Every event below has an ordinary observable method and an `Observe...` async-observable method, except `InterceptingClientEnqueue`, which is synchronous only.
+Every event below has an ordinary observable method and an `Observe...` async-observable method.
 
 | Ordinary method | Async-observable method |
 | --- | --- |
+| `ApplicationMessageEnqueuedOrDropped` | `ObserveApplicationMessageEnqueuedOrDropped` |
 | `ApplicationMessageNotConsumed` | `ObserveApplicationMessageNotConsumed` |
 | `ClientAcknowledgedPublishPacket` | `ObserveClientAcknowledgedPublishPacket` |
 | `ClientConnected` | `ObserveClientConnected` |
 | `ClientDisconnected` | `ObserveClientDisconnected` |
 | `ClientSubscribedTopic` | `ObserveClientSubscribedTopic` |
 | `ClientUnsubscribedTopic` | `ObserveClientUnsubscribedTopic` |
-| `InterceptingClientEnqueue` | — |
+| `InterceptingClientEnqueue` | `ObserveInterceptingClientEnqueue` |
 | `InterceptingInboundPacket` | `ObserveInterceptingInboundPacket` |
 | `InterceptingOutboundPacket` | `ObserveInterceptingOutboundPacket` |
 | `InterceptingPublish` | `ObserveInterceptingPublish` |
@@ -872,6 +1032,7 @@ Every event below has an ordinary observable method and an `Observe...` async-ob
 | `InterceptingUnsubscription` | `ObserveInterceptingUnsubscription` |
 | `LoadingRetainedMessage` | `ObserveLoadingRetainedMessage` |
 | `PreparingSession` | `ObservePreparingSession` |
+| `QueuedApplicationMessageOverwritten` | `ObserveQueuedApplicationMessageOverwritten` |
 | `RetainedMessageChanged` | `ObserveRetainedMessageChanged` |
 | `RetainedMessagesCleared` | `ObserveRetainedMessagesCleared` |
 | `SessionDeleted` | `ObserveSessionDeleted` |
@@ -879,11 +1040,88 @@ Every event below has an ordinary observable method and an `Observe...` async-ob
 | `Stopped` | `ObserveStopped` |
 | `ValidatingConnection` | `ObserveValidatingConnection` |
 
+## ASP.NET Core hosting
+
+`MQTTnet.Rx.AspNetCore` wraps every non-obsolete `MQTTnet.AspNetCore` registration and hosting entry point with receiver-preserving fluent methods. It also projects hosted-server state and connection operations into ordinary and cancellation-aware asynchronous observables. The matching `MQTTnet.Rx.Server` package is transitive, so hosted brokers also receive the complete server event, operation, property, and configuration surface.
+
+```csharp
+using MQTTnet.Rx.AspNetCore;
+using MQTTnet.Rx.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .WithMqttConnections()
+    .WithMqttServer(options => options
+        .WithoutDefaultEndpoint());
+
+var app = builder.Build();
+app.MapMqttEndpoint("/mqtt");
+
+app.ConfigureMqttServer(server => server
+    .WithAcceptNewConnections(true)
+    .WithServerSessionItem("environment", app.Environment.EnvironmentName));
+
+await app.RunAsync();
+```
+
+The fluent service surface includes hosted-server overloads for prebuilt options, options-builder callbacks, and service-aware `AspNetMqttServerOptionsBuilder` callbacks, plus MQTT logging, connection-handler, connection infrastructure, TCP adapter, and WebSocket adapter registration. Endpoint and pipeline methods cover `MapMqtt`, `UseMqtt`, and `UseMqttServer`. MQTTnet's obsolete `UseMqttEndpoint` is intentionally not wrapped; use `MapMqttEndpoint` with endpoint routing.
+
+`MqttHostedServer` exposes `WithAcceptNewConnections`, server-session item configuration, `IsStartedChanges()`, and `ObserveIsStarted()`. `MqttConnectionContext` exposes a complete `MqttConnectionProperties` snapshot, statistics reset, and reactive connect, disconnect, send, and receive operations. Low-level MQTTnet buffer, pipe, and socket implementation types remain available from `MQTTnet.AspNetCore` but are not hosting configuration. The transport adapters' `ClientHandler` delegates are also intentionally not replaceable: MQTTnet owns them while the broker is running, and overriding them would bypass broker session processing.
+
+The `.Reactive` package compiles the same source in `MQTTnet.Rx.AspNetCore.Reactive`; import `MQTTnet.Rx.Server.Reactive` for base-server extensions and use the corresponding System.Reactive operators and `Unit` values.
+
 ## Industrial bridges
 
 The industrial packages bridge device values to MQTT and MQTT payloads back to devices. The application remains responsible for creating and configuring the driver object; the examples use `GetConfigured...` placeholders for that application-specific work.
 
 All bridges provide ordinary raw-client and resilient-client forms. Async-observable forms use `IObservableAsync<IMqttClient>` or `IObservableAsync<IResilientMqttClient>` and return `IObservableAsync<T>` for publications. Static `Create` methods are compatibility forwarders; extension methods are normally clearer and, for S7/TwinCAT subscriptions, preserve the returned lifetime handle.
+
+The client model changes the publication result but not the bridge's device arguments:
+
+| MQTT client sequence | Publication result |
+| --- | --- |
+| `IObservable<IMqttClient>` | `IObservable<MqttClientPublishResult>` |
+| `IObservable<IResilientMqttClient>` | `IObservable<ApplicationMessageProcessedEventArgs>` |
+| `IObservableAsync<IMqttClient>` | `IObservableAsync<MqttClientPublishResult>` |
+| `IObservableAsync<IResilientMqttClient>` | `IObservableAsync<ApplicationMessageProcessedEventArgs>` |
+
+For example, the same Modbus master can feed resilient and async-observable clients. The other industrial packages follow the same receiver/result pattern with their device-specific arguments:
+
+```csharp
+using IoT.Driver.ModbusRx.Device;
+using MQTTnet.Rx.Client;
+using MQTTnet.Rx.Modbus;
+using ReactiveUI.Primitives;
+using ReactiveUI.Primitives.Async;
+
+ModbusIpMaster master = GetConfiguredModbusMaster();
+var modbus = MQTTnet.Rx.Modbus.Create.FromMaster(master);
+
+var resilientClients = MQTTnet.Rx.Client.Create.ResilientMqttClient()
+    .WithResilientClientOptions(options => options.WithClientOptions(mqtt => mqtt
+        .WithTcpServer("localhost", 1883)));
+
+using var resilientPublishing = resilientClients
+    .PublishInputRegisters(modbus, "plant/input", 0, 8)
+    .Subscribe(result => Console.WriteLine(result.Exception));
+
+var asyncClients = MQTTnet.Rx.Client.Create.MqttClientSignal()
+    .WithClientOptions(options => options.WithTcpServer("localhost", 1883));
+var asyncModbus = MQTTnet.Rx.Modbus.ObservableAsyncCreateExtensions.FromMasterAsync(master);
+var asyncPublishing = asyncClients.PublishInputRegisters(asyncModbus, "plant/input-async", 0, 8);
+
+await using var asyncLifetime = await asyncPublishing.SubscribeAsync(
+    (result, _) =>
+    {
+        Console.WriteLine(result.ReasonCode);
+        return ValueTask.CompletedTask;
+    });
+
+static ModbusIpMaster GetConfiguredModbusMaster() => throw new NotImplementedException();
+```
+
+Keep the returned `IDisposable` or `IAsyncDisposable` for as long as the device-to-MQTT bridge should run. An async resilient bridge uses `ResilientMqttClientSignal()` with the same call and emits `ApplicationMessageProcessedEventArgs`.
 
 ### Allen-Bradley
 
@@ -916,7 +1154,7 @@ static IABPlcRx GetConfiguredAllenBradleyClient() => throw new NotImplementedExc
 
 ### Mitsubishi
 
-Mitsubishi bridges use a typed `LogicalTagKey<T>` and `MitsubishiLogicalTagClient`. Publication accepts a `Func<T,string>` formatter. Subscription accepts a `Func<string,T>` parser, optional error callback, and cancellation token; writes are serialized and disposal cancels pending work.
+Mitsubishi bridges use a typed `LogicalTagKey<T>` and `MitsubishiLogicalTagClient`. Publication accepts a `Func<T,string>` formatter. Subscription accepts a `Func<string,T>` parser, a required-but-nullable error callback (pass `null` to omit it), and a cancellation token; writes are serialized and disposal cancels pending work.
 
 ```csharp
 using IoT.Driver.Core;
@@ -954,7 +1192,7 @@ static LogicalTagKey<int> GetMitsubishiSpeedTag() => throw new NotImplementedExc
 
 ### Omron
 
-`PublishOmronPlcTag<T>` and `SubscribeOmronPlcTag<T>` use `IOmronPlcRx` and `LogicalTagKey<T>`. Write failures are reported through tracing by the driver bridge.
+`PublishOmronPlcTag<T>` and `SubscribeOmronPlcTag<T>` use `IOmronPlcRx` and `LogicalTagKey<T>`. Source-sequence failures are sent to the supplied trace callback. Exceptions thrown while parsing an MQTT payload or performing the synchronous PLC write propagate from the notification; handle them in the surrounding pipeline or in the parser/writer implementation.
 
 ```csharp
 using IoT.Driver.Core;
@@ -1020,7 +1258,7 @@ static LogicalTagKey<double> GetS7PressureTag() => throw new NotImplementedExcep
 
 ### Serial port
 
-`PublishSerialPort` buffers data between observable start and end delimiters and publishes complete frames. `SubscribeSerialPortWriteLine` appends the driver's line ending. `SubscribeSerialPortWrite` writes either a transformed string or byte array.
+`PublishSerialPort` buffers data between observable start and end delimiters and publishes complete frames. `SubscribeSerialPortWriteLine` appends the driver's line ending. `SubscribeSerialPortWrite` writes either a transformed string or byte array. The `timeOut` argument is expressed in milliseconds.
 
 ```csharp
 using IoT.Driver.Serial;
@@ -1062,12 +1300,14 @@ static ISerialPortRx GetConfiguredSerialPort() => throw new NotImplementedExcept
 TwinCAT packages are Windows-only. Publication supports both `IRxTcAdsClient` and `IHashTableRx`. MQTT-to-tag extension methods return `IDisposable`. The static compatibility `Create.SubscribeTcTag` methods return `void`, so prefer extension syntax for lifecycle ownership.
 
 ```csharp
+using CP.Collections;
 using IoT.Driver.TwinCATRx;
 using MQTTnet.Rx.Client;
 using MQTTnet.Rx.TwinCAT;
 using ReactiveUI.Primitives;
 
 IRxTcAdsClient ads = GetConfiguredAdsClient();
+IHashTableRx symbols = GetConfiguredSymbolTable();
 var clients = MQTTnet.Rx.Client.Create.MqttClient()
     .WithClientOptions(options => options.WithTcpServer("localhost", 1883))
     .Publish()
@@ -1075,6 +1315,10 @@ var clients = MQTTnet.Rx.Client.Create.MqttClient()
 
 using var publish = clients
     .PublishTcPlcTag<double>("plc/twincat/temperature", "MAIN.Temperature", ads)
+    .Subscribe();
+
+using var publishFromTable = clients
+    .PublishTcPlcTag<double>("plc/twincat/pressure", "MAIN.Pressure", symbols)
     .Subscribe();
 
 using var write = clients.SubscribeTcTag(
@@ -1086,6 +1330,7 @@ using var write = clients.SubscribeTcTag(
         System.Globalization.CultureInfo.InvariantCulture));
 
 static IRxTcAdsClient GetConfiguredAdsClient() => throw new NotImplementedException();
+static IHashTableRx GetConfiguredSymbolTable() => throw new NotImplementedException();
 ```
 
 The `IHashTableRx` overload family is available for publication in synchronous and asynchronous extension APIs. See the complete API for the precise current overload set.
@@ -1106,6 +1351,9 @@ using ReactiveUI.Primitives;
 
 ModbusIpMaster master = GetConfiguredModbusMaster();
 var modbus = MQTTnet.Rx.Modbus.Create.FromMaster(master);
+var scopedModbus = MQTTnet.Rx.Modbus.Create.FromFactory(GetConfiguredModbusMaster);
+var asyncScopedModbus = MQTTnet.Rx.Modbus.ObservableAsyncCreateExtensions
+    .FromFactoryAsync(GetConfiguredModbusMaster);
 var clients = MQTTnet.Rx.Client.Create.MqttClient()
     .WithClientOptions(options => options.WithTcpServer("localhost", 1883))
     .Publish()
@@ -1121,7 +1369,7 @@ using var inputRegisters = clients.PublishInputRegisters(
     retain: false).Subscribe();
 
 using var holdingRegisters = clients.PublishHoldingRegisters(
-    modbus,
+    scopedModbus,
     "modbus/holding-registers",
     startAddress: 0,
     numberOfPoints: 8,
@@ -1216,11 +1464,11 @@ using var customWrite = clients.SubscribeWrite(
 
 ## Complete public API
 
-The reference below is generated from every public source declaration in the nine lean projects. It includes all public types, enum values, constructors, properties, events, methods, extension receivers, overloads, default values, and generic constraints. Static compatibility forwarders are included even when an equivalent extension form exists.
+The reference below is synchronized with every public source declaration in the ten lean projects. It includes all public types, enum values, constructors, properties, events, methods, extension receivers, overloads, default values, and generic constraints. Static compatibility forwarders are included even when an equivalent extension form exists.
 
 The collapsed blocks use compact signature notation rather than complete compilation units. In particular, C# 14 extension blocks are shown as `extension(receiver) { member; }`, and implementation bodies are omitted. Use the feature examples above for copy/paste programs.
 
-The nine `.Reactive` projects compile these same files with `REACTIVE_SHIM`; therefore every listed API is also present in the matching `.Reactive` namespace. Apply these substitutions when reading a signature:
+The ten `.Reactive` projects compile these same files with `REACTIVE_SHIM`; therefore every listed API is also present in the matching `.Reactive` namespace. Apply these substitutions when reading a signature:
 
 - namespace `MQTTnet.Rx.<component>` becomes `MQTTnet.Rx.<component>.Reactive`;
 - `RxVoid`/`RxUnit` completion values become `System.Reactive.Unit`;
@@ -1230,10 +1478,11 @@ The nine `.Reactive` projects compile these same files with `REACTIVE_SHIM`; the
 <!-- PUBLIC_API_START -->
 
 <details>
-<summary>Type index (61 exported types)</summary>
+<summary>Type index (86 exported types)</summary>
 
-- **MQTTnet.Rx.Client:** [`ApplicationMessageProcessedEventArgs`](#api-mqttnet-rx-client-applicationmessageprocessedeventargs), [`ApplicationMessageSkippedEventArgs`](#api-mqttnet-rx-client-applicationmessageskippedeventargs), [`ClientOptionsExtensions`](#api-mqttnet-rx-client-clientoptionsextensions), [`ConnectingFailedEventArgs`](#api-mqttnet-rx-client-connectingfailedeventargs), [`ConnectionExtensions`](#api-mqttnet-rx-client-connectionextensions), [`Create`](#api-mqttnet-rx-client-create), [`CreateExtensions`](#api-mqttnet-rx-client-createextensions), [`IResilientMqttClient`](#api-mqttnet-rx-client-iresilientmqttclient), [`IResilientMqttClientStorage`](#api-mqttnet-rx-client-iresilientmqttclientstorage), [`InterceptingPublishMessageEventArgs`](#api-mqttnet-rx-client-interceptingpublishmessageeventargs), [`LastWillExtensions`](#api-mqttnet-rx-client-lastwillextensions), [`Linq.IGroupedObservable`](#api-mqttnet-rx-client-linq-igroupedobservable), [`MemoryEfficient.BufferPool`](#api-mqttnet-rx-client-memoryefficient-bufferpool), [`MemoryEfficient.BufferScope`](#api-mqttnet-rx-client-memoryefficient-bufferscope), [`MemoryEfficient.LowAllocExtensions`](#api-mqttnet-rx-client-memoryefficient-lowallocextensions), [`MemoryEfficient.ObservableAsyncBridgeExtensions`](#api-mqttnet-rx-client-memoryefficient-observableasyncbridgeextensions), [`MqttClientExtensions`](#api-mqttnet-rx-client-mqttclientextensions), [`MqttPendingMessagesOverflowStrategy`](#api-mqttnet-rx-client-mqttpendingmessagesoverflowstrategy), [`MqttdPublishExtensions`](#api-mqttnet-rx-client-mqttdpublishextensions), [`MqttdSubscribeExtensions`](#api-mqttnet-rx-client-mqttdsubscribeextensions), [`ObservableAsyncBridgeExtensions`](#api-mqttnet-rx-client-observableasyncbridgeextensions), [`ObservableBridgeCompatibilityExtensions`](#api-mqttnet-rx-client-observablebridgecompatibilityextensions), [`PayloadExtensions`](#api-mqttnet-rx-client-payloadextensions), [`ReactiveClientOperations`](#api-mqttnet-rx-client-reactiveclientoperations), [`ReactiveClientOperationsExtensions`](#api-mqttnet-rx-client-reactiveclientoperationsextensions), [`ReconnectionResult`](#api-mqttnet-rx-client-reconnectionresult), [`ResilientMqttApplicationMessage`](#api-mqttnet-rx-client-resilientmqttapplicationmessage), [`ResilientMqttClientFactory`](#api-mqttnet-rx-client-resilientmqttclientfactory), [`ResilientMqttClientOptions`](#api-mqttnet-rx-client-resilientmqttclientoptions), [`ResilientMqttClientOptionsBuilder`](#api-mqttnet-rx-client-resilientmqttclientoptionsbuilder), [`ResilientProcessFailedEventArgs`](#api-mqttnet-rx-client-resilientprocessfailedeventargs), [`SubscriptionsChangedEventArgs`](#api-mqttnet-rx-client-subscriptionschangedeventargs), [`TopicFilterExtensions`](#api-mqttnet-rx-client-topicfilterextensions), [`MemoryEfficient.SpanParser`](#api-mqttnet-rx-client-memoryefficient-spanparser)
-- **MQTTnet.Rx.Server:** [`Create`](#api-mqttnet-rx-server-create), [`IMqttRetainedMessageModel`](#api-mqttnet-rx-server-imqttretainedmessagemodel), [`MqttRetainedMessageModel`](#api-mqttnet-rx-server-mqttretainedmessagemodel), [`MqttServerExtensions`](#api-mqttnet-rx-server-mqttserverextensions), [`MqttServerSession`](#api-mqttnet-rx-server-mqttserversession)
+- **MQTTnet.Rx.Client:** [`ApplicationMessageProcessedEventArgs`](#api-mqttnet-rx-client-applicationmessageprocessedeventargs), [`ApplicationMessageSkippedEventArgs`](#api-mqttnet-rx-client-applicationmessageskippedeventargs), [`ClientOptionsExtensions`](#api-mqttnet-rx-client-clientoptionsextensions), [`ConnectingFailedEventArgs`](#api-mqttnet-rx-client-connectingfailedeventargs), [`ConnectionExtensions`](#api-mqttnet-rx-client-connectionextensions), [`Create`](#api-mqttnet-rx-client-create), [`CreateExtensions`](#api-mqttnet-rx-client-createextensions), [`IResilientMqttClient`](#api-mqttnet-rx-client-iresilientmqttclient), [`IResilientMqttClientStorage`](#api-mqttnet-rx-client-iresilientmqttclientstorage), [`InterceptingPublishMessageEventArgs`](#api-mqttnet-rx-client-interceptingpublishmessageeventargs), [`LastWillExtensions`](#api-mqttnet-rx-client-lastwillextensions), [`Linq.IGroupedObservable`](#api-mqttnet-rx-client-linq-igroupedobservable), [`MemoryEfficient.BufferPool`](#api-mqttnet-rx-client-memoryefficient-bufferpool), [`MemoryEfficient.BufferScope`](#api-mqttnet-rx-client-memoryefficient-bufferscope), [`MemoryEfficient.LowAllocExtensions`](#api-mqttnet-rx-client-memoryefficient-lowallocextensions), [`MemoryEfficient.ObservableAsyncBridgeExtensions`](#api-mqttnet-rx-client-memoryefficient-observableasyncbridgeextensions), [`MqttClientAsyncAutoReconnectExtensions`](#api-mqttnet-rx-client-mqttclientasyncautoreconnectextensions), [`MqttClientExtensions`](#api-mqttnet-rx-client-mqttclientextensions), [`MqttClientOperationExtensions`](#api-mqttnet-rx-client-mqttclientoperationextensions), [`MqttClientProperties`](#api-mqttnet-rx-client-mqttclientproperties), [`MqttClientPropertyExtensions`](#api-mqttnet-rx-client-mqttclientpropertyextensions), [`MqttClientSequenceOperationExtensions`](#api-mqttnet-rx-client-mqttclientsequenceoperationextensions), [`MqttPendingMessagesOverflowStrategy`](#api-mqttnet-rx-client-mqttpendingmessagesoverflowstrategy), [`MqttdPublishExtensions`](#api-mqttnet-rx-client-mqttdpublishextensions), [`MqttdSubscribeExtensions`](#api-mqttnet-rx-client-mqttdsubscribeextensions), [`ObservableAsyncBridgeExtensions`](#api-mqttnet-rx-client-observableasyncbridgeextensions), [`ObservableBridgeCompatibilityExtensions`](#api-mqttnet-rx-client-observablebridgecompatibilityextensions), [`PayloadExtensions`](#api-mqttnet-rx-client-payloadextensions), [`ReactiveClientOperations`](#api-mqttnet-rx-client-reactiveclientoperations), [`ReactiveClientOperationsExtensions`](#api-mqttnet-rx-client-reactiveclientoperationsextensions), [`ReconnectionResult`](#api-mqttnet-rx-client-reconnectionresult), [`ResilientMqttApplicationMessage`](#api-mqttnet-rx-client-resilientmqttapplicationmessage), [`ResilientMqttClientFactory`](#api-mqttnet-rx-client-resilientmqttclientfactory), [`ResilientMqttClientOperationExtensions`](#api-mqttnet-rx-client-resilientmqttclientoperationextensions), [`ResilientMqttClientOptions`](#api-mqttnet-rx-client-resilientmqttclientoptions), [`ResilientMqttClientOptionsBuilder`](#api-mqttnet-rx-client-resilientmqttclientoptionsbuilder), [`ResilientMqttClientProperties`](#api-mqttnet-rx-client-resilientmqttclientproperties), [`ResilientMqttClientPropertyExtensions`](#api-mqttnet-rx-client-resilientmqttclientpropertyextensions), [`ResilientProcessFailedEventArgs`](#api-mqttnet-rx-client-resilientprocessfailedeventargs), [`SubscriptionsChangedEventArgs`](#api-mqttnet-rx-client-subscriptionschangedeventargs), [`TopicFilterExtensions`](#api-mqttnet-rx-client-topicfilterextensions), [`MemoryEfficient.SpanParser`](#api-mqttnet-rx-client-memoryefficient-spanparser)
+- **MQTTnet.Rx.Server:** [`Create`](#api-mqttnet-rx-server-create), [`IMqttRetainedMessageModel`](#api-mqttnet-rx-server-imqttretainedmessagemodel), [`MqttClientStatusExtensions`](#api-mqttnet-rx-server-mqttclientstatusextensions), [`MqttClientStatusProperties`](#api-mqttnet-rx-server-mqttclientstatusproperties), [`MqttRetainedMessageModel`](#api-mqttnet-rx-server-mqttretainedmessagemodel), [`MqttServerConfigurationExtensions`](#api-mqttnet-rx-server-mqttserverconfigurationextensions), [`MqttServerExtensions`](#api-mqttnet-rx-server-mqttserverextensions), [`MqttServerOperationExtensions`](#api-mqttnet-rx-server-mqttserveroperationextensions), [`MqttServerOptionsConfigurationExtensions`](#api-mqttnet-rx-server-mqttserveroptionsconfigurationextensions), [`MqttServerProperties`](#api-mqttnet-rx-server-mqttserverproperties), [`MqttServerPropertyExtensions`](#api-mqttnet-rx-server-mqttserverpropertyextensions), [`MqttServerSequenceConfigurationExtensions`](#api-mqttnet-rx-server-mqttserversequenceconfigurationextensions), [`MqttServerSession`](#api-mqttnet-rx-server-mqttserversession), [`MqttSessionEnqueueResult`](#api-mqttnet-rx-server-mqttsessionenqueueresult), [`MqttSessionStatusExtensions`](#api-mqttnet-rx-server-mqttsessionstatusextensions), [`MqttSessionStatusProperties`](#api-mqttnet-rx-server-mqttsessionstatusproperties), [`ValidatingConnectionOperationExtensions`](#api-mqttnet-rx-server-validatingconnectionoperationextensions)
+- **MQTTnet.Rx.AspNetCore:** [`MqttAspNetCoreHostingExtensions`](#api-mqttnet-rx-aspnetcore-mqttaspnetcorehostingextensions), [`MqttAspNetCoreServiceCollectionExtensions`](#api-mqttnet-rx-aspnetcore-mqttaspnetcoreservicecollectionextensions), [`MqttConnectionContextExtensions`](#api-mqttnet-rx-aspnetcore-mqttconnectioncontextextensions), [`MqttConnectionProperties`](#api-mqttnet-rx-aspnetcore-mqttconnectionproperties), [`MqttHostedServerExtensions`](#api-mqttnet-rx-aspnetcore-mqtthostedserverextensions)
 - **MQTTnet.Rx.ABPlc:** [`Create`](#api-mqttnet-rx-abplc-create), [`CreateExtensions`](#api-mqttnet-rx-abplc-createextensions), [`ObservableAsyncCreateExtensionMixins`](#api-mqttnet-rx-abplc-observableasynccreateextensionmixins), [`ObservableAsyncCreateExtensions`](#api-mqttnet-rx-abplc-observableasynccreateextensions)
 - **MQTTnet.Rx.Mitsubishi:** [`MitsubishiMqttExtensions`](#api-mqttnet-rx-mitsubishi-mitsubishimqttextensions), [`ObservableAsyncCreateExtensions`](#api-mqttnet-rx-mitsubishi-observableasynccreateextensions)
 - **MQTTnet.Rx.Modbus:** [`Create`](#api-mqttnet-rx-modbus-create), [`CreateExtensions`](#api-mqttnet-rx-modbus-createextensions), [`ObservableAsyncCreateExtensionMixins`](#api-mqttnet-rx-modbus-observableasynccreateextensionmixins), [`ObservableAsyncCreateExtensions`](#api-mqttnet-rx-modbus-observableasynccreateextensions), [`SerializationExtensions`](#api-mqttnet-rx-modbus-serializationextensions)
@@ -1334,7 +1583,7 @@ extension(IResilientMqttClient client) { public IObservableAsync<SubscriptionsCh
 
 ```text
 public static class Create
-public static MqttClientFactory MqttFactory { get; private set; } = new();
+public static MqttClientFactory MqttFactory { get; }
 public static void NewMqttFactory(MqttClientFactory mqttFactory)
 public static IObservable<IMqttClient> MqttClient()
 public static IObservableAsync<IMqttClient> MqttClientSignal()
@@ -1588,6 +1837,18 @@ extension(IObservableAsync<MqttApplicationMessageReceivedEventArgs> source) { pu
 ```
 </details>
 
+<a id="api-mqttnet-rx-client-mqttclientasyncautoreconnectextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.MqttClientAsyncAutoReconnectExtensions</code></summary>
+
+```text
+public static class MqttClientAsyncAutoReconnectExtensions
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<IMqttClient> WithAutoReconnect(); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<IMqttClient> WithAutoReconnect(TimeSpan? reconnectDelay); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<IMqttClient> WithAutoReconnect(TimeSpan? reconnectDelay, int maxReconnectAttempts); }
+```
+</details>
+
 <a id="api-mqttnet-rx-client-mqttclientextensions"></a>
 <details>
 <summary><code>MQTTnet.Rx.Client.MqttClientExtensions</code></summary>
@@ -1602,8 +1863,113 @@ extension(IMqttClient client) { public IObservable<MqttClientConnectingEventArgs
 extension(IMqttClient client) { public IObservableAsync<MqttClientConnectingEventArgs> ObserveConnecting(); }
 extension(IMqttClient client) { public IObservable<MqttClientDisconnectedEventArgs> Disconnected(); }
 extension(IMqttClient client) { public IObservableAsync<MqttClientDisconnectedEventArgs> ObserveDisconnected(); }
-extension(IMqttClient client) { public IObservable<InspectMqttPacketEventArgs> InspectPackage(); }
-extension(IMqttClient client) { public IObservableAsync<InspectMqttPacketEventArgs> ObserveInspectPackage(); }
+extension(IMqttClient client) { public IObservable<InspectMqttPacketEventArgs> InspectPacket(); }
+extension(IMqttClient client) { public IObservableAsync<InspectMqttPacketEventArgs> ObserveInspectPacket(); }
+```
+</details>
+
+<a id="api-mqttnet-rx-client-mqttclientoperationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.MqttClientOperationExtensions</code></summary>
+
+```text
+public static class MqttClientOperationExtensions
+extension(IMqttClient client) { public IObservable<MqttClientConnectResult> Connect(MqttClientOptions options); }
+extension(IMqttClient client) { public IObservable<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientConnectResult> ObserveConnect(MqttClientOptions options); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientConnectResult> ObserveConnect(Action<MqttClientOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservable<RxUnit> Disconnect(MqttClientDisconnectOptions options); }
+extension(IMqttClient client) { public IObservable<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservableAsync<RxUnit> ObserveDisconnect(MqttClientDisconnectOptions options); }
+extension(IMqttClient client) { public IObservableAsync<RxUnit> ObserveDisconnect(Action<MqttClientDisconnectOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservable<RxUnit> Ping(); }
+extension(IMqttClient client) { public IObservableAsync<RxUnit> ObservePing(); }
+extension(IMqttClient client) { public IObservable<MqttClientPublishResult> Publish(MqttApplicationMessage message); }
+extension(IMqttClient client) { public IObservable<MqttClientPublishResult> Publish(Action<MqttApplicationMessageBuilder> configure); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientPublishResult> ObservePublish(MqttApplicationMessage message); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientPublishResult> ObservePublish(Action<MqttApplicationMessageBuilder> configure); }
+extension(IMqttClient client) { public IObservable<MqttClientPublishResult> PublishBinary(string topic, IEnumerable<byte>? payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientPublishResult> ObservePublishBinary(string topic, IEnumerable<byte>? payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservable<MqttClientPublishResult> PublishSequence(string topic, ReadOnlySequence<byte> payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientPublishResult> ObservePublishSequence(string topic, ReadOnlySequence<byte> payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservable<MqttClientPublishResult> PublishString(string topic, string? payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientPublishResult> ObservePublishString(string topic, string? payload, MqttQualityOfServiceLevel qualityOfServiceLevel, bool retain); }
+extension(IMqttClient client) { public IObservable<RxUnit> Reconnect(); }
+extension(IMqttClient client) { public IObservableAsync<RxUnit> ObserveReconnect(); }
+extension(IMqttClient client) { public IObservable<RxUnit> SendEnhancedAuthenticationExchangeData(MqttEnhancedAuthenticationExchangeData data); }
+extension(IMqttClient client) { public IObservableAsync<RxUnit> ObserveSendEnhancedAuthenticationExchangeData(MqttEnhancedAuthenticationExchangeData data); }
+extension(IMqttClient client) { public IObservable<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options); }
+extension(IMqttClient client) { public IObservable<MqttClientSubscribeResult> Subscribe(Action<MqttClientSubscribeOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientSubscribeResult> ObserveSubscribe(MqttClientSubscribeOptions options); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientSubscribeResult> ObserveSubscribe(Action<MqttClientSubscribeOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservable<bool> TryDisconnect(); }
+extension(IMqttClient client) { public IObservable<bool> TryDisconnect(MqttClientDisconnectOptionsReason reason, string? reasonString); }
+extension(IMqttClient client) { public IObservableAsync<bool> ObserveTryDisconnect(); }
+extension(IMqttClient client) { public IObservableAsync<bool> ObserveTryDisconnect(MqttClientDisconnectOptionsReason reason, string? reasonString); }
+extension(IMqttClient client) { public IObservable<bool> TryPing(); }
+extension(IMqttClient client) { public IObservableAsync<bool> ObserveTryPing(); }
+extension(IMqttClient client) { public IObservable<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options); }
+extension(IMqttClient client) { public IObservable<MqttClientUnsubscribeResult> Unsubscribe(Action<MqttClientUnsubscribeOptionsBuilder> configure); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientUnsubscribeResult> ObserveUnsubscribe(MqttClientUnsubscribeOptions options); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientUnsubscribeResult> ObserveUnsubscribe(Action<MqttClientUnsubscribeOptionsBuilder> configure); }
+```
+</details>
+
+<a id="api-mqttnet-rx-client-mqttclientproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.MqttClientProperties</code></summary>
+
+```text
+public sealed record MqttClientProperties(bool IsConnected, MqttClientOptions? Options)
+public bool IsConnected { get; init; }
+public MqttClientOptions? Options { get; init; }
+```
+</details>
+
+<a id="api-mqttnet-rx-client-mqttclientpropertyextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.MqttClientPropertyExtensions</code></summary>
+
+```text
+public static class MqttClientPropertyExtensions
+extension(IMqttClient client) { public MqttClientProperties Properties(); }
+extension(IMqttClient client) { public IObservable<T> Property<T>(Func<IMqttClient, T> selector); }
+extension(IMqttClient client) { public IObservableAsync<T> ObserveProperty<T>(Func<IMqttClient, T> selector); }
+extension(IMqttClient client) { public IObservable<MqttClientProperties> PropertySnapshots(); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientProperties> ObservePropertySnapshots(); }
+extension(IMqttClient client) { public IObservable<bool> IsConnectedValue(); }
+extension(IMqttClient client) { public IObservableAsync<bool> ObserveIsConnected(); }
+extension(IMqttClient client) { public IObservable<MqttClientOptions?> OptionsSnapshot(); }
+extension(IMqttClient client) { public IObservableAsync<MqttClientOptions?> ObserveOptionsSnapshot(); }
+```
+</details>
+
+<a id="api-mqttnet-rx-client-mqttclientsequenceoperationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.MqttClientSequenceOperationExtensions</code></summary>
+
+```text
+public static class MqttClientSequenceOperationExtensions
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientConnectResult> Connect(MqttClientOptions options); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure); }
+extension(IObservable<IMqttClient> clients) { public IObservable<RxUnit> Disconnect(MqttClientDisconnectOptions options); }
+extension(IObservable<IMqttClient> clients) { public IObservable<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientPublishResult> Publish(MqttApplicationMessage message); }
+extension(IObservable<IMqttClient> clients) { public IObservable<RxUnit> SendEnhancedAuthenticationExchangeData(MqttEnhancedAuthenticationExchangeData data); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientSubscribeResult> Subscribe(Action<MqttClientSubscribeOptionsBuilder> configure); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options); }
+extension(IObservable<IMqttClient> clients) { public IObservable<MqttClientUnsubscribeResult> Unsubscribe(Action<MqttClientUnsubscribeOptionsBuilder> configure); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientConnectResult> Connect(MqttClientOptions options); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<RxUnit> Disconnect(MqttClientDisconnectOptions options); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientPublishResult> Publish(MqttApplicationMessage message); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<RxUnit> SendEnhancedAuthenticationExchangeData(MqttEnhancedAuthenticationExchangeData data); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientSubscribeResult> Subscribe(Action<MqttClientSubscribeOptionsBuilder> configure); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options); }
+extension(IObservableAsync<IMqttClient> clients) { public IObservableAsync<MqttClientUnsubscribeResult> Unsubscribe(Action<MqttClientUnsubscribeOptionsBuilder> configure); }
 ```
 </details>
 
@@ -1902,6 +2268,33 @@ public static IResilientMqttClient Create(IMqttClient mqttClient, IMqttNetLogger
 ```
 </details>
 
+<a id="api-mqttnet-rx-client-resilientmqttclientoperationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.ResilientMqttClientOperationExtensions</code></summary>
+
+```text
+public static class ResilientMqttClientOperationExtensions
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Enqueue(MqttApplicationMessage message); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Enqueue(ResilientMqttApplicationMessage message); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveEnqueue(MqttApplicationMessage message); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveEnqueue(ResilientMqttApplicationMessage message); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Ping(); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObservePing(); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Start(ResilientMqttClientOptions options); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Start(Action<ResilientMqttClientOptionsBuilder> configure); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveStart(ResilientMqttClientOptions options); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveStart(Action<ResilientMqttClientOptionsBuilder> configure); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Stop(); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Stop(bool cleanDisconnect); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveStop(); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveStop(bool cleanDisconnect); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Subscribe(IEnumerable<MqttTopicFilter> topicFilters); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveSubscribe(IEnumerable<MqttTopicFilter> topicFilters); }
+extension(IResilientMqttClient client) { public IObservable<RxUnit> Unsubscribe(IEnumerable<string> topics); }
+extension(IResilientMqttClient client) { public IObservableAsync<RxUnit> ObserveUnsubscribe(IEnumerable<string> topics); }
+```
+</details>
+
 <a id="api-mqttnet-rx-client-resilientmqttclientoptions"></a>
 <details>
 <summary><code>MQTTnet.Rx.Client.ResilientMqttClientOptions</code></summary>
@@ -1933,6 +2326,35 @@ public ResilientMqttClientOptionsBuilder WithClientOptions(MqttClientOptionsBuil
 public ResilientMqttClientOptionsBuilder WithClientOptions( Action<MqttClientOptionsBuilder> options)
 public ResilientMqttClientOptionsBuilder WithMaxTopicFiltersInSubscribeUnsubscribePackets( int value)
 public ResilientMqttClientOptions Build()
+```
+</details>
+
+<a id="api-mqttnet-rx-client-resilientmqttclientproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.ResilientMqttClientProperties</code></summary>
+
+```text
+public sealed record ResilientMqttClientProperties(IMqttClient InternalClient, bool IsConnected, bool IsStarted, ResilientMqttClientOptions? Options, int PendingApplicationMessagesCount)
+public IMqttClient InternalClient { get; init; }
+public bool IsConnected { get; init; }
+public bool IsStarted { get; init; }
+public ResilientMqttClientOptions? Options { get; init; }
+public int PendingApplicationMessagesCount { get; init; }
+```
+</details>
+
+<a id="api-mqttnet-rx-client-resilientmqttclientpropertyextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Client.ResilientMqttClientPropertyExtensions</code></summary>
+
+```text
+public static class ResilientMqttClientPropertyExtensions
+extension(IResilientMqttClient client) { public ResilientMqttClientProperties Properties(); }
+extension(IResilientMqttClient client) { public IObservable<T> Property<T>(Func<IResilientMqttClient, T> selector); }
+extension(IResilientMqttClient client) { public IObservableAsync<T> ObserveProperty<T>(Func<IResilientMqttClient, T> selector); }
+extension(IResilientMqttClient client) { public IObservable<ResilientMqttClientProperties> PropertySnapshots(); }
+extension(IResilientMqttClient client) { public IObservableAsync<ResilientMqttClientProperties> ObservePropertySnapshots(); }
+extension(IResilientMqttClient client) { public IObservable<SubscriptionsChangedEventArgs> SubscriptionsChanged(); }
 ```
 </details>
 
@@ -2024,6 +2446,36 @@ MqttApplicationMessage ToApplicationMessage();
 ```
 </details>
 
+<a id="api-mqttnet-rx-server-mqttclientstatusextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttClientStatusExtensions</code></summary>
+
+```text
+public static class MqttClientStatusExtensions
+extension(MqttClientStatus client) { public MqttClientStatusProperties Properties(); }
+extension(MqttClientStatus client) { public IObservable<T> Property<T>(Func<MqttClientStatus, T> selector); }
+extension(MqttClientStatus client) { public IObservableAsync<T> ObserveProperty<T>(Func<MqttClientStatus, T> selector); }
+extension(MqttClientStatus client) { public IObservable<MqttClientStatusProperties> PropertySnapshots(); }
+extension(MqttClientStatus client) { public IObservableAsync<MqttClientStatusProperties> ObservePropertySnapshots(); }
+extension(MqttClientStatus client) { public IObservable<RxVoid> Disconnect(MqttServerClientDisconnectOptions options); }
+extension(MqttClientStatus client) { public IObservable<RxVoid> Disconnect(Action<MqttServerClientDisconnectOptionsBuilder> configure); }
+extension(MqttClientStatus client) { public IObservableAsync<RxVoid> ObserveDisconnect(MqttServerClientDisconnectOptions options); }
+extension(MqttClientStatus client) { public IObservableAsync<RxVoid> ObserveDisconnect(Action<MqttServerClientDisconnectOptionsBuilder> configure); }
+extension(MqttClientStatus client) { public IObservable<RxVoid> ResetStatisticsOperation(); }
+extension(MqttClientStatus client) { public IObservableAsync<RxVoid> ObserveResetStatistics(); }
+extension(MqttClientStatus client) { public MqttClientStatus WithSession(MqttSessionStatus session); }
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttclientstatusproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttClientStatusProperties</code></summary>
+
+```text
+public sealed record MqttClientStatusProperties(long BytesReceived, long BytesSent, DateTimeOffset ConnectedTimestamp, EndPoint? RemoteEndPoint, string? Endpoint, string Id, DateTimeOffset LastNonKeepAlivePacketReceivedTimestamp, DateTimeOffset LastPacketReceivedTimestamp, DateTimeOffset LastPacketSentTimestamp, MqttProtocolVersion ProtocolVersion, long ReceivedApplicationMessagesCount, long ReceivedPacketsCount, long SentApplicationMessagesCount, long SentPacketsCount, MqttSessionStatus Session)
+```
+</details>
+
 <a id="api-mqttnet-rx-server-mqttretainedmessagemodel"></a>
 <details>
 <summary><code>MQTTnet.Rx.Server.MqttRetainedMessageModel</code></summary>
@@ -2043,12 +2495,28 @@ public MqttApplicationMessage ToApplicationMessage()
 ```
 </details>
 
+<a id="api-mqttnet-rx-server-mqttserverconfigurationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerConfigurationExtensions</code></summary>
+
+```text
+public static class MqttServerConfigurationExtensions
+extension(MqttServer server) { public MqttServer WithAcceptNewConnections(bool value); }
+extension(MqttServer server) { public MqttServer WithServerSessionItem(object key, object value); }
+extension(MqttServer server) { public MqttServer WithoutServerSessionItem(object key); }
+extension(MqttServer server) { public MqttServer ClearServerSessionItems(); }
+extension(MqttServer server) { public MqttServer ConfigureServer(Action<MqttServer> configure); }
+```
+</details>
+
 <a id="api-mqttnet-rx-server-mqttserverextensions"></a>
 <details>
 <summary><code>MQTTnet.Rx.Server.MqttServerExtensions</code></summary>
 
 ```text
 public static class MqttServerExtensions
+extension(MqttServer server) { public IObservable<ApplicationMessageEnqueuedEventArgs> ApplicationMessageEnqueuedOrDropped(); }
+extension(MqttServer server) { public IObservableAsync<ApplicationMessageEnqueuedEventArgs> ObserveApplicationMessageEnqueuedOrDropped(); }
 extension(MqttServer server) { public IObservable<ApplicationMessageNotConsumedEventArgs> ApplicationMessageNotConsumed(); }
 extension(MqttServer server) { public IObservableAsync<ApplicationMessageNotConsumedEventArgs> ObserveApplicationMessageNotConsumed(); }
 extension(MqttServer server) { public IObservable<ClientAcknowledgedPublishPacketEventArgs> ClientAcknowledgedPublishPacket(); }
@@ -2077,6 +2545,8 @@ extension(MqttServer server) { public IObservable<LoadingRetainedMessagesEventAr
 extension(MqttServer server) { public IObservableAsync<LoadingRetainedMessagesEventArgs> ObserveLoadingRetainedMessage(); }
 extension(MqttServer server) { public IObservable<EventArgs> PreparingSession(); }
 extension(MqttServer server) { public IObservableAsync<EventArgs> ObservePreparingSession(); }
+extension(MqttServer server) { public IObservable<QueueMessageOverwrittenEventArgs> QueuedApplicationMessageOverwritten(); }
+extension(MqttServer server) { public IObservableAsync<QueueMessageOverwrittenEventArgs> ObserveQueuedApplicationMessageOverwritten(); }
 extension(MqttServer server) { public IObservable<RetainedMessageChangedEventArgs> RetainedMessageChanged(); }
 extension(MqttServer server) { public IObservableAsync<RetainedMessageChangedEventArgs> ObserveRetainedMessageChanged(); }
 extension(MqttServer server) { public IObservable<EventArgs> RetainedMessagesCleared(); }
@@ -2092,6 +2562,101 @@ extension(MqttServer server) { public IObservableAsync<ValidatingConnectionEvent
 ```
 </details>
 
+<a id="api-mqttnet-rx-server-mqttserveroperationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerOperationExtensions</code></summary>
+
+```text
+public static class MqttServerOperationExtensions
+extension(MqttServer server) { public IObservable<RxVoid> DeleteRetainedMessages(); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveDeleteRetainedMessages(); }
+extension(MqttServer server) { public IObservable<RxVoid> DisconnectClient(string clientId, MqttServerClientDisconnectOptions options); }
+extension(MqttServer server) { public IObservable<RxVoid> DisconnectClient(string clientId, Action<MqttServerClientDisconnectOptionsBuilder> configure); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveDisconnectClient(string clientId, MqttServerClientDisconnectOptions options); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveDisconnectClient(string clientId, Action<MqttServerClientDisconnectOptionsBuilder> configure); }
+extension(MqttServer server) { public IObservable<IList<MqttClientStatus>> GetClients(); }
+extension(MqttServer server) { public IObservableAsync<IList<MqttClientStatus>> ObserveClients(); }
+extension(MqttServer server) { public IObservable<MqttApplicationMessage> GetRetainedMessage(string topic); }
+extension(MqttServer server) { public IObservableAsync<MqttApplicationMessage> ObserveRetainedMessage(string topic); }
+extension(MqttServer server) { public IObservable<IList<MqttApplicationMessage>> GetRetainedMessages(); }
+extension(MqttServer server) { public IObservableAsync<IList<MqttApplicationMessage>> ObserveRetainedMessages(); }
+extension(MqttServer server) { public IObservable<MqttSessionStatus> GetSession(string clientId); }
+extension(MqttServer server) { public IObservableAsync<MqttSessionStatus> ObserveSession(string clientId); }
+extension(MqttServer server) { public IObservable<IList<MqttSessionStatus>> GetSessions(); }
+extension(MqttServer server) { public IObservableAsync<IList<MqttSessionStatus>> ObserveSessions(); }
+extension(MqttServer server) { public IObservable<RxVoid> InjectApplicationMessageOperation(InjectedMqttApplicationMessage message); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveInjectApplicationMessage(InjectedMqttApplicationMessage message); }
+extension(MqttServer server) { public IObservable<RxVoid> Start(); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveStart(); }
+extension(MqttServer server) { public IObservable<RxVoid> Stop(); }
+extension(MqttServer server) { public IObservable<RxVoid> Stop(MqttServerStopOptions options); }
+extension(MqttServer server) { public IObservable<RxVoid> Stop(Action<MqttServerStopOptionsBuilder> configure); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveStop(); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveStop(MqttServerStopOptions options); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveStop(Action<MqttServerStopOptionsBuilder> configure); }
+extension(MqttServer server) { public IObservable<RxVoid> SubscribeClient(string clientId, ICollection<MqttTopicFilter> topicFilters); }
+extension(MqttServer server) { public IObservable<RxVoid> SubscribeClient(string clientId, Action<MqttTopicFilterBuilder> configure); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveSubscribeClient(string clientId, ICollection<MqttTopicFilter> topicFilters); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveSubscribeClient(string clientId, Action<MqttTopicFilterBuilder> configure); }
+extension(MqttServer server) { public IObservable<RxVoid> UnsubscribeClient(string clientId, ICollection<string> topicFilters); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveUnsubscribeClient(string clientId, ICollection<string> topicFilters); }
+extension(MqttServer server) { public IObservable<RxVoid> UpdateRetainedMessage(MqttApplicationMessage message); }
+extension(MqttServer server) { public IObservableAsync<RxVoid> ObserveUpdateRetainedMessage(MqttApplicationMessage message); }
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttserveroptionsconfigurationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerOptionsConfigurationExtensions</code></summary>
+
+```text
+public static class MqttServerOptionsConfigurationExtensions
+extension(MqttServerClientDisconnectOptionsBuilder builder) { public MqttServerClientDisconnectOptionsBuilder ConfigureOptions(Action<MqttServerClientDisconnectOptions> configure); }
+extension(MqttServerOptionsBuilder builder) { public MqttServerOptionsBuilder ConfigureOptions(Action<MqttServerOptions> configure); }
+extension(MqttServerStopOptionsBuilder builder) { public MqttServerStopOptionsBuilder ConfigureOptions(Action<MqttServerStopOptions> configure); }
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttserverproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerProperties</code></summary>
+
+```text
+public sealed record MqttServerProperties(bool AcceptNewConnections, bool IsStarted, IReadOnlyDictionary<object, object?> ServerSessionItems)
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttserverpropertyextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerPropertyExtensions</code></summary>
+
+```text
+public static class MqttServerPropertyExtensions
+extension(MqttServer server) { public MqttServerProperties Properties(); }
+extension(MqttServer server) { public IObservable<T> Property<T>(Func<MqttServer, T> selector); }
+extension(MqttServer server) { public IObservableAsync<T> ObserveProperty<T>(Func<MqttServer, T> selector); }
+extension(MqttServer server) { public IObservable<MqttServerProperties> PropertySnapshots(); }
+extension(MqttServer server) { public IObservableAsync<MqttServerProperties> ObservePropertySnapshots(); }
+extension(MqttServer server) { public IObservable<bool> AcceptNewConnectionsValue(); }
+extension(MqttServer server) { public IObservableAsync<bool> ObserveAcceptNewConnections(); }
+extension(MqttServer server) { public IObservable<IReadOnlyDictionary<object, object?>> ServerSessionItemsSnapshot(); }
+extension(MqttServer server) { public IObservableAsync<IReadOnlyDictionary<object, object?>> ObserveServerSessionItemsSnapshot(); }
+extension(MqttServer server) { public IObservable<bool> IsStartedChanges(); }
+extension(MqttServer server) { public IObservableAsync<bool> ObserveIsStartedChanges(); }
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttserversequenceconfigurationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttServerSequenceConfigurationExtensions</code></summary>
+
+```text
+public static class MqttServerSequenceConfigurationExtensions
+extension(IObservable<MqttServer> servers) { public IObservable<MqttServer> ConfigureServer(Action<MqttServer> configure); }
+extension(IObservableAsync<MqttServer> servers) { public IObservableAsync<MqttServer> ConfigureServer(Action<MqttServer> configure); }
+```
+</details>
+
 <a id="api-mqttnet-rx-server-mqttserversession"></a>
 <details>
 <summary><code>MQTTnet.Rx.Server.MqttServerSession</code></summary>
@@ -2103,6 +2668,144 @@ public MqttServer Server { get; }
 public void Add(IDisposable resource)
 public void Dispose()
 public async ValueTask DisposeAsync()
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttsessionenqueueresult"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttSessionEnqueueResult</code></summary>
+
+```text
+public sealed record MqttSessionEnqueueResult(bool IsEnqueued, InjectMqttApplicationMessageResult? InjectResult)
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttsessionstatusextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttSessionStatusExtensions</code></summary>
+
+```text
+public static class MqttSessionStatusExtensions
+extension(MqttSessionStatus session) { public MqttSessionStatusProperties Properties(); }
+extension(MqttSessionStatus session) { public IObservable<T> Property<T>(Func<MqttSessionStatus, T> selector); }
+extension(MqttSessionStatus session) { public IObservableAsync<T> ObserveProperty<T>(Func<MqttSessionStatus, T> selector); }
+extension(MqttSessionStatus session) { public IObservable<MqttSessionStatusProperties> PropertySnapshots(); }
+extension(MqttSessionStatus session) { public IObservableAsync<MqttSessionStatusProperties> ObservePropertySnapshots(); }
+extension(MqttSessionStatus session) { public MqttSessionStatus WithSessionItem(object key, object value); }
+extension(MqttSessionStatus session) { public MqttSessionStatus WithoutSessionItem(object key); }
+extension(MqttSessionStatus session) { public MqttSessionStatus ClearSessionItems(); }
+extension(MqttSessionStatus session) { public IObservable<RxVoid> ClearApplicationMessagesQueue(); }
+extension(MqttSessionStatus session) { public IObservableAsync<RxVoid> ObserveClearApplicationMessagesQueue(); }
+extension(MqttSessionStatus session) { public IObservable<RxVoid> Delete(); }
+extension(MqttSessionStatus session) { public IObservableAsync<RxVoid> ObserveDelete(); }
+extension(MqttSessionStatus session) { public IObservable<InjectMqttApplicationMessageResult> DeliverApplicationMessage(MqttApplicationMessage message); }
+extension(MqttSessionStatus session) { public IObservableAsync<InjectMqttApplicationMessageResult> ObserveDeliverApplicationMessage(MqttApplicationMessage message); }
+extension(MqttSessionStatus session) { public IObservable<MqttSessionEnqueueResult> TryEnqueueApplicationMessage(MqttApplicationMessage message); }
+extension(MqttSessionStatus session) { public IObservableAsync<MqttSessionEnqueueResult> ObserveTryEnqueueApplicationMessage(MqttApplicationMessage message); }
+```
+</details>
+
+<a id="api-mqttnet-rx-server-mqttsessionstatusproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.MqttSessionStatusProperties</code></summary>
+
+```text
+public sealed record MqttSessionStatusProperties(DateTimeOffset CreatedTimestamp, DateTimeOffset? DisconnectedTimestamp, uint ExpiryInterval, string Id, IReadOnlyDictionary<object, object?> Items, long PendingApplicationMessagesCount)
+```
+</details>
+
+<a id="api-mqttnet-rx-server-validatingconnectionoperationextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.Server.ValidatingConnectionOperationExtensions</code></summary>
+
+```text
+public static class ValidatingConnectionOperationExtensions
+extension(ValidatingConnectionEventArgs eventArgs) { public IObservable<ExchangeEnhancedAuthenticationResult> ExchangeEnhancedAuthentication(ExchangeEnhancedAuthenticationOptions options); }
+extension(ValidatingConnectionEventArgs eventArgs) { public IObservableAsync<ExchangeEnhancedAuthenticationResult> ObserveExchangeEnhancedAuthentication(ExchangeEnhancedAuthenticationOptions options); }
+```
+</details>
+
+<a id="mqttnetrxaspnetcore-api"></a>
+### `MQTTnet.Rx.AspNetCore`
+
+<a id="api-mqttnet-rx-aspnetcore-mqttaspnetcorehostingextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.AspNetCore.MqttAspNetCoreHostingExtensions</code></summary>
+
+```text
+public static class MqttAspNetCoreHostingExtensions
+extension(IApplicationBuilder app) { public IApplicationBuilder ConfigureMqttServer(Action<MqttServer> configure); }
+extension(IConnectionBuilder builder) { public IConnectionBuilder UseMqttConnectionHandler(); }
+extension(IEndpointRouteBuilder endpoints) { public IEndpointRouteBuilder MapMqttEndpoint(string pattern); }
+```
+</details>
+
+<a id="api-mqttnet-rx-aspnetcore-mqttaspnetcoreservicecollectionextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.AspNetCore.MqttAspNetCoreServiceCollectionExtensions</code></summary>
+
+```text
+public static class MqttAspNetCoreServiceCollectionExtensions
+extension(IServiceCollection services) { public IServiceCollection WithHostedMqttServer(); }
+extension(IServiceCollection services) { public IServiceCollection WithHostedMqttServer(MqttServerOptions options); }
+extension(IServiceCollection services) { public IServiceCollection WithHostedMqttServer(Action<MqttServerOptionsBuilder>? configure); }
+extension(IServiceCollection services) { public IServiceCollection WithHostedMqttServerServices(Action<AspNetMqttServerOptionsBuilder> configure); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttConnectionHandler(); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttConnections(); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttLogger(IMqttNetLogger logger); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttServer(); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttServer(Action<MqttServerOptionsBuilder>? configure); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttTcpServerAdapter(); }
+extension(IServiceCollection services) { public IServiceCollection WithMqttWebSocketServerAdapter(); }
+```
+</details>
+
+<a id="api-mqttnet-rx-aspnetcore-mqttconnectioncontextextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.AspNetCore.MqttConnectionContextExtensions</code></summary>
+
+```text
+public static class MqttConnectionContextExtensions
+extension(MqttConnectionContext connection) { public MqttConnectionProperties Properties(); }
+extension(MqttConnectionContext connection) { public MqttConnectionContext ResetConnectionStatistics(); }
+extension(MqttConnectionContext connection) { public IObservable<RxVoid> Connect(); }
+extension(MqttConnectionContext connection) { public IObservableAsync<RxVoid> ConnectSignal(); }
+extension(MqttConnectionContext connection) { public IObservable<RxVoid> Disconnect(); }
+extension(MqttConnectionContext connection) { public IObservableAsync<RxVoid> DisconnectSignal(); }
+extension(MqttConnectionContext connection) { public IObservable<MqttPacket> ReceivePacket(); }
+extension(MqttConnectionContext connection) { public IObservableAsync<MqttPacket> ReceivePacketSignal(); }
+extension(MqttConnectionContext connection) { public IObservable<RxVoid> SendPacket(MqttPacket packet); }
+extension(MqttConnectionContext connection) { public IObservableAsync<RxVoid> SendPacketSignal(MqttPacket packet); }
+```
+</details>
+
+<a id="api-mqttnet-rx-aspnetcore-mqttconnectionproperties"></a>
+<details>
+<summary><code>MQTTnet.Rx.AspNetCore.MqttConnectionProperties</code></summary>
+
+```text
+public sealed record MqttConnectionProperties( long BytesReceived, long BytesSent, X509Certificate2? ClientCertificate, bool IsSecureConnection, EndPoint? LocalEndPoint, EndPoint? RemoteEndPoint, MqttPacketFormatterAdapter PacketFormatterAdapter)
+public long BytesReceived { get; init; }
+public long BytesSent { get; init; }
+public X509Certificate2? ClientCertificate { get; init; }
+public bool IsSecureConnection { get; init; }
+public EndPoint? LocalEndPoint { get; init; }
+public EndPoint? RemoteEndPoint { get; init; }
+public MqttPacketFormatterAdapter PacketFormatterAdapter { get; init; }
+```
+</details>
+
+<a id="api-mqttnet-rx-aspnetcore-mqtthostedserverextensions"></a>
+<details>
+<summary><code>MQTTnet.Rx.AspNetCore.MqttHostedServerExtensions</code></summary>
+
+```text
+public static class MqttHostedServerExtensions
+extension(MqttHostedServer server) { public MqttHostedServer WithAcceptNewConnections(bool acceptNewConnections); }
+extension(MqttHostedServer server) { public MqttHostedServer WithServerSessionItem(object key, object value); }
+extension(MqttHostedServer server) { public MqttHostedServer ConfigureHostedServer(Action<MqttHostedServer> configure); }
+extension(MqttHostedServer server) { public IObservable<bool> IsStartedChanges(); }
+extension(MqttHostedServer server) { public IObservableAsync<bool> ObserveIsStarted(); }
 ```
 </details>
 
@@ -2252,56 +2955,56 @@ public static T? DeSerialize<T>(string value, params T[] typeWitness)
 
 ```text
 public static partial class CreateExtensions
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
-extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<ModbusMasterState> modbus, string topic, Func<string, T> parse, Action<ModbusIpMaster, T> writer); }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<ModbusMasterState> modbus, string topic, Func<string, T> parse, Func<ModbusIpMaster, T, Task> writerAsync); }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteSingleRegister( IObservable<ModbusMasterState> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, ushort> writer); }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteMultipleRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, ushort[]> writer); }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteSingleCoil( IObservable<ModbusMasterState> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, bool> writer); }
-extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteMultipleCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, bool[]> writer); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
-extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<ModbusReaderState> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<ModbusMasterState> modbus, string topic, Func<string, T> parse, Action<ModbusIpMaster, T> writer); }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<ModbusMasterState> modbus, string topic, Func<string, T> parse, Func<ModbusIpMaster, T, Task> writerAsync); }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteSingleRegister( IObservable<ModbusMasterState> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, ushort> writer); }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteMultipleRegisters( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, ushort[]> writer); }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteSingleCoil( IObservable<ModbusMasterState> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, bool> writer); }
-extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteMultipleCoils( IObservable<ModbusMasterState> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, bool[]> writer); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
+extension(IObservable<IResilientMqttClient> client) { public IObservable<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, Func<string, T> parse, Action<ModbusIpMaster, T> writer); }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, Func<string, T> parse, Func<ModbusIpMaster, T, Task> writerAsync); }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteSingleRegister( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, ushort> writer); }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteMultipleRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, ushort[]> writer); }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteSingleCoil( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, bool> writer); }
+extension(IObservable<IResilientMqttClient> client) { public IDisposable SubscribeWriteMultipleCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, bool[]> writer); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishHoldingRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishInputs( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
+extension(IObservable<IMqttClient> client) { public IObservable<MqttClientPublishResult> PublishModbus<TPayload>( IObservable<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, Func<string, T> parse, Action<ModbusIpMaster, T> writer); }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWrite<T>( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, Func<string, T> parse, Func<ModbusIpMaster, T, Task> writerAsync); }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteSingleRegister( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, ushort> writer); }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteMultipleRegisters( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, ushort[]> writer); }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteSingleCoil( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort address, Action<ModbusIpMaster, ushort, bool> writer); }
+extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteMultipleCoils( IObservable<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, Action<ModbusIpMaster, ushort, bool[]> writer); }
 ```
 </details>
 
@@ -2311,44 +3014,44 @@ extension(IObservable<IMqttClient> client) { public IDisposable SubscribeWriteMu
 
 ```text
 public static partial class ObservableAsyncCreateExtensionMixins
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
-extension(IObservableAsync<IMqttClient> client) { public PublishResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishHoldingRegisters( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishInputs( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishCoils( ModbusMasterSignal modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
-extension(IObservableAsync<IResilientMqttClient> client) { public ResilientResult PublishModbus<TPayload>( ModbusReaderSignal reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
+extension(IObservableAsync<IMqttClient> client) { public IObservableAsync<MqttClientPublishResult> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishHoldingRegisters( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishInputs( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishCoils( IObservableAsync<(bool Connected, Exception? Error, ModbusIpMaster? Master)> modbus, string topic, ushort startAddress, ushort numberOfPoints, double interval, MqttQualityOfServiceLevel qos, bool retain); }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory) where TPayload : notnull; }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos) where TPayload : notnull; }
+extension(IObservableAsync<IResilientMqttClient> client) { public IObservableAsync<ApplicationMessageProcessedEventArgs> PublishModbus<TPayload>( IObservableAsync<(bool Connected, Exception? Error, object? Data)> reader, string topic, Func<object, TPayload> payloadFactory, MqttQualityOfServiceLevel qos, bool retain) where TPayload : notnull; }
 ```
 </details>
 

--- a/src/MQTTnet.Rx.AspNetCore.Reactive/MQTTnet.Rx.AspNetCore.Reactive.csproj
+++ b/src/MQTTnet.Rx.AspNetCore.Reactive/MQTTnet.Rx.AspNetCore.Reactive.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(MQTTnetRxTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+    <PackageId>MQTTnet.Rx.AspNetCore.Reactive</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="MQTTnet.AspNetCore" />
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" />
+    <PackageReference Include="ReactiveUI.Primitives.Async.Reactive" />
+    <ProjectReference Include="..\MQTTnet.Rx.Server.Reactive\MQTTnet.Rx.Server.Reactive.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\MQTTnet.Rx.AspNetCore\**\*.cs"
+             Exclude="..\MQTTnet.Rx.AspNetCore\bin\**;..\MQTTnet.Rx.AspNetCore\obj\**"
+             Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.AspNetCore.Builder" />
+    <Using Include="Microsoft.AspNetCore.Connections" />
+    <Using Include="Microsoft.AspNetCore.Routing" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="MQTTnet.AspNetCore" />
+    <Using Include="MQTTnet.Diagnostics.Logger" />
+    <Using Include="MQTTnet.Formatter" />
+    <Using Include="MQTTnet.Packets" />
+    <Using Include="MQTTnet.Rx.Server.Reactive" />
+    <Using Include="MQTTnet.Server" />
+    <Using Include="ReactiveUI.Primitives.Async" />
+    <Using Include="ReactiveUI.Primitives.Reactive" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Signals" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Signals.Signal" Alias="SignalFactory" />
+    <Using Include="System.Reactive.Unit" Alias="RxVoid" />
+    <Using Include="System.Net" />
+    <Using Include="System.Security.Cryptography.X509Certificates" />
+  </ItemGroup>
+</Project>

--- a/src/MQTTnet.Rx.AspNetCore/MQTTnet.Rx.AspNetCore.csproj
+++ b/src/MQTTnet.Rx.AspNetCore/MQTTnet.Rx.AspNetCore.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(MQTTnetRxTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>MQTTnet.Rx.AspNetCore</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="MQTTnet.AspNetCore" />
+    <PackageReference Include="ReactiveUI.Primitives" />
+    <PackageReference Include="ReactiveUI.Primitives.Async" />
+    <ProjectReference Include="..\MQTTnet.Rx.Server\MQTTnet.Rx.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.AspNetCore.Builder" />
+    <Using Include="Microsoft.AspNetCore.Connections" />
+    <Using Include="Microsoft.AspNetCore.Routing" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="MQTTnet.AspNetCore" />
+    <Using Include="MQTTnet.Diagnostics.Logger" />
+    <Using Include="MQTTnet.Formatter" />
+    <Using Include="MQTTnet.Packets" />
+    <Using Include="MQTTnet.Rx.Server" />
+    <Using Include="MQTTnet.Server" />
+    <Using Include="ReactiveUI.Primitives" />
+    <Using Include="ReactiveUI.Primitives.Async" />
+    <Using Include="ReactiveUI.Primitives.RxVoid" Alias="RxVoid" />
+    <Using Include="ReactiveUI.Primitives.Signals" />
+    <Using Include="ReactiveUI.Primitives.Signals.Signal" Alias="SignalFactory" />
+    <Using Include="System.Net" />
+    <Using Include="System.Security.Cryptography.X509Certificates" />
+  </ItemGroup>
+</Project>

--- a/src/MQTTnet.Rx.AspNetCore/MqttAspNetCoreHostingExtensions.cs
+++ b/src/MQTTnet.Rx.AspNetCore/MqttAspNetCoreHostingExtensions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.AspNetCore.Reactive;
+#else
+namespace MQTTnet.Rx.AspNetCore;
+#endif
+
+/// <summary>Provides return-preserving MQTTnet ASP.NET Core hosting extensions.</summary>
+public static class MqttAspNetCoreHostingExtensions
+{
+    /// <summary>Provides hosted MQTT server configuration.</summary>
+    /// <param name="app">The application builder.</param>
+    extension(IApplicationBuilder app)
+    {
+        /// <summary>Configures the hosted MQTT server resolved from application services.</summary>
+        /// <param name="configure">The server configuration callback.</param>
+        /// <returns>The same application builder.</returns>
+        public IApplicationBuilder ConfigureMqttServer(Action<MqttServer> configure)
+        {
+            _ = MQTTnet.AspNetCore.ApplicationBuilderExtensions.UseMqttServer(app, configure);
+            return app;
+        }
+    }
+
+    /// <summary>Provides MQTT connection middleware configuration.</summary>
+    /// <param name="builder">The connection builder.</param>
+    extension(IConnectionBuilder builder)
+    {
+        /// <summary>Adds the MQTT connection handler to a connection pipeline.</summary>
+        /// <returns>The same connection builder.</returns>
+        public IConnectionBuilder UseMqttConnectionHandler()
+        {
+            _ = MQTTnet.AspNetCore.ConnectionBuilderExtensions.UseMqtt(builder);
+            return builder;
+        }
+    }
+
+    /// <summary>Provides MQTT endpoint mapping.</summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    extension(IEndpointRouteBuilder endpoints)
+    {
+        /// <summary>Maps an MQTT WebSocket endpoint.</summary>
+        /// <param name="pattern">The endpoint route pattern.</param>
+        /// <returns>The same endpoint route builder.</returns>
+        public IEndpointRouteBuilder MapMqttEndpoint(string pattern)
+        {
+            MQTTnet.AspNetCore.EndpointRouterExtensions.MapMqtt(endpoints, pattern);
+            return endpoints;
+        }
+    }
+}

--- a/src/MQTTnet.Rx.AspNetCore/MqttAspNetCoreServiceCollectionExtensions.cs
+++ b/src/MQTTnet.Rx.AspNetCore/MqttAspNetCoreServiceCollectionExtensions.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.AspNetCore.Reactive;
+#else
+namespace MQTTnet.Rx.AspNetCore;
+#endif
+
+/// <summary>Provides fluent MQTTnet ASP.NET Core service-registration extensions.</summary>
+public static class MqttAspNetCoreServiceCollectionExtensions
+{
+    /// <summary>Provides fluent MQTT service registration.</summary>
+    /// <param name="services">The service collection being configured.</param>
+    extension(IServiceCollection services)
+    {
+        /// <summary>Adds hosted MQTT server services after server options have been registered.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithHostedMqttServer()
+        {
+            MQTTnet.AspNetCore.ServiceCollectionExtensions.AddHostedMqttServer(services);
+            return services;
+        }
+
+        /// <summary>Adds a hosted MQTT server using prebuilt options.</summary>
+        /// <param name="options">The server options.</param>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithHostedMqttServer(MqttServerOptions options)
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddHostedMqttServer(services, options);
+            return services;
+        }
+
+        /// <summary>Adds a hosted MQTT server configured by a server-options builder.</summary>
+        /// <param name="configure">The optional options-builder callback.</param>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithHostedMqttServer(Action<MqttServerOptionsBuilder>? configure)
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddHostedMqttServer(services, configure);
+            return services;
+        }
+
+        /// <summary>Adds a hosted MQTT server whose options callback can resolve application services.</summary>
+        /// <param name="configure">The service-aware options-builder callback.</param>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithHostedMqttServerServices(Action<AspNetMqttServerOptionsBuilder> configure)
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddHostedMqttServerWithServices(services, configure);
+            return services;
+        }
+
+        /// <summary>Adds the MQTT connection handler adapter.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttConnectionHandler()
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddMqttConnectionHandler(services);
+            return services;
+        }
+
+        /// <summary>Adds the ASP.NET Core connections services required by endpoint routing.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttConnections()
+        {
+            _ = services.AddConnections();
+            return services;
+        }
+
+        /// <summary>Adds an MQTTnet logger.</summary>
+        /// <param name="logger">The logger instance.</param>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttLogger(IMqttNetLogger logger)
+        {
+            MQTTnet.AspNetCore.ServiceCollectionExtensions.AddMqttLogger(services, logger);
+            return services;
+        }
+
+        /// <summary>Adds a complete hosted MQTT server with its connection handler.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttServer() => services.WithMqttServer(null);
+
+        /// <summary>Adds a complete hosted MQTT server with its connection handler.</summary>
+        /// <param name="configure">The optional server-options callback.</param>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttServer(Action<MqttServerOptionsBuilder>? configure)
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddMqttServer(services, configure);
+            return services;
+        }
+
+        /// <summary>Adds the MQTT TCP server adapter.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttTcpServerAdapter()
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddMqttTcpServerAdapter(services);
+            return services;
+        }
+
+        /// <summary>Adds the MQTT WebSocket server adapter.</summary>
+        /// <returns>The same service collection.</returns>
+        public IServiceCollection WithMqttWebSocketServerAdapter()
+        {
+            _ = MQTTnet.AspNetCore.ServiceCollectionExtensions.AddMqttWebSocketServerAdapter(services);
+            return services;
+        }
+    }
+}

--- a/src/MQTTnet.Rx.AspNetCore/MqttConnectionContextExtensions.cs
+++ b/src/MQTTnet.Rx.AspNetCore/MqttConnectionContextExtensions.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.AspNetCore.Reactive;
+#else
+namespace MQTTnet.Rx.AspNetCore;
+#endif
+
+/// <summary>Provides reactive operations and property snapshots for MQTT ASP.NET Core connections.</summary>
+public static class MqttConnectionContextExtensions
+{
+    /// <summary>Provides reactive connection operations.</summary>
+    /// <param name="connection">The MQTT connection context.</param>
+    extension(MqttConnectionContext connection)
+    {
+        /// <summary>Captures all public connection properties.</summary>
+        /// <returns>The current connection-property snapshot.</returns>
+        public MqttConnectionProperties Properties() => new(
+            connection.BytesReceived,
+            connection.BytesSent,
+            connection.ClientCertificate,
+            connection.IsSecureConnection,
+            connection.LocalEndPoint,
+            connection.RemoteEndPoint,
+            connection.PacketFormatterAdapter);
+
+        /// <summary>Resets the connection byte counters.</summary>
+        /// <returns>The same connection context.</returns>
+        public MqttConnectionContext ResetConnectionStatistics()
+        {
+            connection.ResetStatistics();
+            return connection;
+        }
+
+        /// <summary>Creates a cold observable that connects when subscribed.</summary>
+        /// <returns>A connection operation sequence.</returns>
+        public IObservable<RxVoid> Connect() => SignalFactory.FromAsync(
+            async cancellationToken =>
+            {
+                await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                return RxVoid.Default;
+            });
+
+        /// <summary>Creates a cold asynchronous observable that connects when subscribed.</summary>
+        /// <returns>An asynchronous connection operation sequence.</returns>
+        public IObservableAsync<RxVoid> ConnectSignal() => SignalAsync.FromAsync(
+            async cancellationToken =>
+            {
+                await connection.ConnectAsync(cancellationToken).ConfigureAwait(false);
+                return RxVoid.Default;
+            });
+
+        /// <summary>Creates a cold observable that disconnects when subscribed.</summary>
+        /// <returns>A disconnection operation sequence.</returns>
+        public IObservable<RxVoid> Disconnect() => SignalFactory.FromAsync(
+            async cancellationToken =>
+            {
+                await connection.DisconnectAsync(cancellationToken).ConfigureAwait(false);
+                return RxVoid.Default;
+            });
+
+        /// <summary>Creates a cold asynchronous observable that disconnects when subscribed.</summary>
+        /// <returns>An asynchronous disconnection operation sequence.</returns>
+        public IObservableAsync<RxVoid> DisconnectSignal() => SignalAsync.FromAsync(
+            async cancellationToken =>
+            {
+                await connection.DisconnectAsync(cancellationToken).ConfigureAwait(false);
+                return RxVoid.Default;
+            });
+
+        /// <summary>Creates a cold observable that receives one packet when subscribed.</summary>
+        /// <returns>A packet receive operation sequence.</returns>
+        public IObservable<MqttPacket> ReceivePacket() =>
+            SignalFactory.FromAsync(connection.ReceivePacketAsync);
+
+        /// <summary>Creates a cold asynchronous observable that receives one packet when subscribed.</summary>
+        /// <returns>An asynchronous packet receive operation sequence.</returns>
+        public IObservableAsync<MqttPacket> ReceivePacketSignal() => SignalAsync.FromAsync(
+            cancellationToken => new ValueTask<MqttPacket>(connection.ReceivePacketAsync(cancellationToken)));
+
+        /// <summary>Creates a cold observable that sends a packet when subscribed.</summary>
+        /// <param name="packet">The MQTT packet to send.</param>
+        /// <returns>A packet send operation sequence.</returns>
+        public IObservable<RxVoid> SendPacket(MqttPacket packet)
+        {
+            ArgumentNullException.ThrowIfNull(packet);
+            return SignalFactory.FromAsync(
+                async cancellationToken =>
+                {
+                    await connection.SendPacketAsync(packet, cancellationToken).ConfigureAwait(false);
+                    return RxVoid.Default;
+                });
+        }
+
+        /// <summary>Creates a cold asynchronous observable that sends a packet when subscribed.</summary>
+        /// <param name="packet">The MQTT packet to send.</param>
+        /// <returns>An asynchronous packet send operation sequence.</returns>
+        public IObservableAsync<RxVoid> SendPacketSignal(MqttPacket packet)
+        {
+            ArgumentNullException.ThrowIfNull(packet);
+            return SignalAsync.FromAsync(
+                async cancellationToken =>
+                {
+                    await connection.SendPacketAsync(packet, cancellationToken).ConfigureAwait(false);
+                    return RxVoid.Default;
+                });
+        }
+    }
+}

--- a/src/MQTTnet.Rx.AspNetCore/MqttConnectionProperties.cs
+++ b/src/MQTTnet.Rx.AspNetCore/MqttConnectionProperties.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.AspNetCore.Reactive;
+#else
+namespace MQTTnet.Rx.AspNetCore;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of an MQTT ASP.NET Core connection.</summary>
+/// <param name="BytesReceived">The number of bytes received.</param>
+/// <param name="BytesSent">The number of bytes sent.</param>
+/// <param name="ClientCertificate">The optional client certificate.</param>
+/// <param name="IsSecureConnection">Whether the connection is secure.</param>
+/// <param name="LocalEndPoint">The optional local endpoint.</param>
+/// <param name="RemoteEndPoint">The optional remote endpoint.</param>
+/// <param name="PacketFormatterAdapter">The packet formatter adapter.</param>
+public sealed record MqttConnectionProperties(
+    long BytesReceived,
+    long BytesSent,
+    X509Certificate2? ClientCertificate,
+    bool IsSecureConnection,
+    EndPoint? LocalEndPoint,
+    EndPoint? RemoteEndPoint,
+    MqttPacketFormatterAdapter PacketFormatterAdapter);

--- a/src/MQTTnet.Rx.AspNetCore/MqttHostedServerExtensions.cs
+++ b/src/MQTTnet.Rx.AspNetCore/MqttHostedServerExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+using ServerPropertyExtensions = MQTTnet.Rx.Server.Reactive.MqttServerPropertyExtensions;
+namespace MQTTnet.Rx.AspNetCore.Reactive;
+#else
+using ServerPropertyExtensions = MQTTnet.Rx.Server.MqttServerPropertyExtensions;
+namespace MQTTnet.Rx.AspNetCore;
+#endif
+
+/// <summary>Provides fluent configuration and reactive state for an ASP.NET Core hosted MQTT server.</summary>
+public static class MqttHostedServerExtensions
+{
+    /// <summary>Provides hosted MQTT server configuration and state.</summary>
+    /// <param name="server">The hosted MQTT server.</param>
+    extension(MqttHostedServer server)
+    {
+        /// <summary>Configures whether the server accepts new connections.</summary>
+        /// <param name="acceptNewConnections">Whether new clients may connect.</param>
+        /// <returns>The same hosted server.</returns>
+        public MqttHostedServer WithAcceptNewConnections(bool acceptNewConnections)
+        {
+            server.AcceptNewConnections = acceptNewConnections;
+            return server;
+        }
+
+        /// <summary>Adds or replaces an item in the hosted server session dictionary.</summary>
+        /// <param name="key">The session-item key.</param>
+        /// <param name="value">The session-item value.</param>
+        /// <returns>The same hosted server.</returns>
+        public MqttHostedServer WithServerSessionItem(object key, object value)
+        {
+            server.ServerSessionItems[key] = value;
+            return server;
+        }
+
+        /// <summary>Applies arbitrary fluent configuration to the hosted server.</summary>
+        /// <param name="configure">The configuration callback.</param>
+        /// <returns>The same hosted server.</returns>
+        public MqttHostedServer ConfigureHostedServer(Action<MqttHostedServer> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            configure(server);
+            return server;
+        }
+
+        /// <summary>Observes the current and subsequent hosted-server started state.</summary>
+        /// <returns>An observable state sequence.</returns>
+        public IObservable<bool> IsStartedChanges() => ServerPropertyExtensions.IsStartedChanges(server);
+
+        /// <summary>Observes the current and subsequent hosted-server started state asynchronously.</summary>
+        /// <returns>An asynchronous observable state sequence.</returns>
+        public IObservableAsync<bool> ObserveIsStarted() =>
+            ServerPropertyExtensions.ObserveIsStartedChanges(server);
+    }
+}

--- a/src/MQTTnet.Rx.Client.Reactive.Tests/MQTTnet.Rx.Client.Reactive.Tests.csproj
+++ b/src/MQTTnet.Rx.Client.Reactive.Tests/MQTTnet.Rx.Client.Reactive.Tests.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MQTTnet.Rx.ABPlc.Reactive\MQTTnet.Rx.ABPlc.Reactive.csproj" />
+    <ProjectReference Include="..\MQTTnet.Rx.AspNetCore.Reactive\MQTTnet.Rx.AspNetCore.Reactive.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Client.Reactive\MQTTnet.Rx.Client.Reactive.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Mitsubishi.Reactive\MQTTnet.Rx.Mitsubishi.Reactive.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Modbus.Reactive\MQTTnet.Rx.Modbus.Reactive.csproj" />

--- a/src/MQTTnet.Rx.Client.Tests/AspNetCoreCoverageTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/AspNetCoreCoverageTests.cs
@@ -1,0 +1,374 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using MQTTnet.AspNetCore;
+using MQTTnet.Diagnostics.Logger;
+using MQTTnet.Formatter;
+using MQTTnet.Packets;
+#if REACTIVE_SHIM
+using MQTTnet.Rx.AspNetCore.Reactive;
+#else
+using MQTTnet.Rx.AspNetCore;
+#endif
+using MQTTnet.Rx.Client.Tests.Helpers;
+using MQTTnet.Server;
+using MQTTnet.Server.Internal.Adapter;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ReactiveUI.Primitives.Async;
+
+namespace MQTTnet.Rx.Client.Tests;
+
+/// <summary>Verifies the ASP.NET Core fluent and reactive package surface.</summary>
+[NotInParallel]
+public sealed class AspNetCoreCoverageTests
+{
+    /// <summary>The initial MQTT packet writer buffer size.</summary>
+    private const int InitialBufferSize = 4_096;
+
+    /// <summary>The maximum MQTT packet writer buffer size.</summary>
+    private const int MaximumBufferSize = 65_535;
+
+    /// <summary>The maximum time allowed for observable operations.</summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>A serialized MQTT ping request.</summary>
+    private static readonly byte[] PingRequestBytes = [0xC0, 0x00];
+
+    /// <summary>A serialized MQTT ping response.</summary>
+    private static readonly byte[] PingResponseBytes = [0xD0, 0x00];
+
+    /// <summary>Verifies the hosted-server registration overloads preserve services and options.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServiceCollectionExtensions_RegisterHostedServerOverloadsFluentlyAsync()
+    {
+        var defaultServices = CreateServices();
+        var defaultOptions = new MqttServerFactory().CreateServerOptionsBuilder().Build();
+        _ = defaultServices.AddSingleton(defaultOptions);
+        await Assert.That(defaultServices.WithHostedMqttServer()).IsSameReferenceAs(defaultServices);
+        await using var defaultProvider = defaultServices.BuildServiceProvider();
+        await Assert.That(defaultProvider.GetRequiredService<MqttHostedServer>()).IsNotNull();
+
+        var factory = new MqttServerFactory();
+        var explicitOptions = factory.CreateServerOptionsBuilder().WithoutDefaultEndpoint().Build();
+        var optionsServices = CreateServices();
+        await Assert.That(optionsServices.WithHostedMqttServer(explicitOptions)).IsSameReferenceAs(optionsServices);
+        await using var optionsProvider = optionsServices.BuildServiceProvider();
+        await Assert.That(optionsProvider.GetRequiredService<MqttServerOptions>()).IsSameReferenceAs(explicitOptions);
+
+        var callbackInvoked = false;
+        var callbackServices = CreateServices();
+        await Assert.That(callbackServices.WithHostedMqttServer(
+            builder =>
+            {
+                callbackInvoked = true;
+                _ = builder.WithoutDefaultEndpoint();
+            })).IsSameReferenceAs(callbackServices);
+        await using var callbackProvider = callbackServices.BuildServiceProvider();
+        _ = callbackProvider.GetRequiredService<MqttServerOptions>();
+        await Assert.That(callbackInvoked).IsTrue();
+    }
+
+    /// <summary>Verifies service-aware hosted-server registration exposes application services.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServiceCollectionExtensions_RegisterServiceAwareHostedServerFluentlyAsync()
+    {
+        var marker = new object();
+        var callbackInvoked = false;
+        var services = CreateServices();
+        _ = services.AddSingleton(marker);
+        await Assert.That(services.WithHostedMqttServerServices(
+            builder =>
+            {
+                callbackInvoked = ReferenceEquals(builder.ServiceProvider.GetRequiredService<object>(), marker);
+                _ = builder.WithoutDefaultEndpoint();
+            })).IsSameReferenceAs(services);
+
+        await using var provider = services.BuildServiceProvider();
+        _ = provider.GetRequiredService<MqttServerOptions>();
+        await Assert.That(callbackInvoked).IsTrue();
+    }
+
+    /// <summary>Verifies adapters, connections, logging, and composite server registrations.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServiceCollectionExtensions_RegisterAdaptersAndCompositeServerFluentlyAsync()
+    {
+        var connectionServices = CreateServices();
+        await Assert.That(connectionServices.WithMqttConnections()).IsSameReferenceAs(connectionServices);
+        await Assert.That(connectionServices.WithMqttConnectionHandler()).IsSameReferenceAs(connectionServices);
+        await using var connectionProvider = connectionServices.BuildServiceProvider();
+        await Assert.That(connectionProvider.GetRequiredService<MqttConnectionHandler>()).IsNotNull();
+        await Assert.That(GetOnlyAdapter(connectionProvider)).IsTypeOf<MqttConnectionHandler>();
+
+        var loggerServices = CreateServices();
+        await Assert.That(loggerServices.WithMqttLogger(MqttNetNullLogger.Instance)).IsSameReferenceAs(loggerServices);
+        await using var loggerProvider = loggerServices.BuildServiceProvider();
+        await Assert.That(loggerProvider.GetRequiredService<IMqttNetLogger>())
+            .IsSameReferenceAs(MqttNetNullLogger.Instance);
+
+        var serverServices = CreateServices();
+        await Assert.That(serverServices.WithMqttServer()).IsSameReferenceAs(serverServices);
+        await using var serverProvider = serverServices.BuildServiceProvider();
+        await Assert.That(serverProvider.GetRequiredService<MqttConnectionHandler>()).IsNotNull();
+    }
+
+    /// <summary>Verifies configured, TCP, and WebSocket adapter registrations.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServiceCollectionExtensions_RegisterConfiguredAndTransportAdaptersFluentlyAsync()
+    {
+        var callbackInvoked = false;
+        var serverServices = CreateServices();
+        await Assert.That(serverServices.WithMqttServer(
+            builder =>
+            {
+                callbackInvoked = true;
+                _ = builder.WithoutDefaultEndpoint();
+            })).IsSameReferenceAs(serverServices);
+        await using var serverProvider = serverServices.BuildServiceProvider();
+        _ = serverProvider.GetRequiredService<MqttServerOptions>();
+        await Assert.That(callbackInvoked).IsTrue();
+
+        var tcpServices = CreateServices();
+        await Assert.That(tcpServices.WithMqttTcpServerAdapter()).IsSameReferenceAs(tcpServices);
+        await using var tcpProvider = tcpServices.BuildServiceProvider();
+        await Assert.That(GetOnlyAdapter(tcpProvider)).IsTypeOf<MqttTcpServerAdapter>();
+
+        var webSocketServices = CreateServices();
+        await Assert.That(webSocketServices.WithMqttWebSocketServerAdapter()).IsSameReferenceAs(webSocketServices);
+        await using var webSocketProvider = webSocketServices.BuildServiceProvider();
+        await Assert.That(webSocketProvider.GetRequiredService<MqttWebSocketServerAdapter>()).IsNotNull();
+    }
+
+    /// <summary>Verifies endpoint, connection, and application hosting helpers preserve their receivers.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task HostingExtensions_PreserveConfiguredBuildersAsync()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddLogging();
+        _ = services.AddRouting();
+        _ = services.AddConnections();
+        _ = services.AddSingleton<IHostApplicationLifetime, TestHostApplicationLifetime>();
+        _ = services.AddSingleton<MqttConnectionHandler>();
+        await using var provider = services.BuildServiceProvider();
+
+        var app = new ApplicationBuilder(provider);
+        var endpoints = new TestEndpointRouteBuilder(app);
+        await Assert.That(endpoints.MapMqttEndpoint("/mqtt")).IsSameReferenceAs(endpoints);
+
+        var connectionBuilder = new ConnectionBuilder(provider);
+        await Assert.That(connectionBuilder.UseMqttConnectionHandler()).IsSameReferenceAs(connectionBuilder);
+
+        var mqttFactory = new MqttServerFactory();
+        using var server = mqttFactory.CreateMqttServer(
+            mqttFactory.CreateServerOptionsBuilder().WithoutDefaultEndpoint().Build());
+        var applicationServices = new ServiceCollection();
+        _ = applicationServices.AddSingleton(server);
+        await using var applicationProvider = applicationServices.BuildServiceProvider();
+        var mqttApplication = new ApplicationBuilder(applicationProvider);
+        var configured = false;
+        await Assert.That(mqttApplication.ConfigureMqttServer(
+            resolvedServer => configured = ReferenceEquals(resolvedServer, server)))
+            .IsSameReferenceAs(mqttApplication);
+        await Assert.That(configured).IsTrue();
+    }
+
+    /// <summary>Verifies hosted-server configuration and both lifecycle state projections.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task HostedServerExtensions_ConfigureAndObserveStartedStateAsync()
+    {
+        var factory = new MqttServerFactory();
+        using var lifetime = new TestHostApplicationLifetime();
+        using var server = new MqttHostedServer(
+            lifetime,
+            factory,
+            factory.CreateServerOptionsBuilder().WithoutDefaultEndpoint().Build(),
+            [],
+            MqttNetNullLogger.Instance);
+
+        await Assert.That(server.WithAcceptNewConnections(false)).IsSameReferenceAs(server);
+        await Assert.That(server.AcceptNewConnections).IsFalse();
+        await Assert.That(server.WithServerSessionItem("key", "value")).IsSameReferenceAs(server);
+        await Assert.That(server.ServerSessionItems["key"]).IsEqualTo("value");
+
+        var configured = false;
+        await Assert.That(server.ConfigureHostedServer(_ => configured = true)).IsSameReferenceAs(server);
+        await Assert.That(configured).IsTrue();
+        await Assert.That(() => server.ConfigureHostedServer(null!)).Throws<ArgumentNullException>();
+
+        var states = new List<bool>();
+        var asyncStates = new List<bool>();
+        using var subscription = server.IsStartedChanges().Subscribe(states.Add);
+        await using var asyncSubscription = await server.ObserveIsStarted().SubscribeAsync(
+            (value, cancellationToken) =>
+            {
+                _ = cancellationToken;
+                asyncStates.Add(value);
+                return ValueTask.CompletedTask;
+            },
+            CancellationToken.None);
+
+        await server.StartAsync();
+        await server.StopAsync(factory.CreateMqttServerStopOptionsBuilder().Build());
+
+        await Assert.That(states).IsEquivalentTo([false, true, false]);
+        await Assert.That(asyncStates).IsEquivalentTo([false, true, false]);
+    }
+
+    /// <summary>Verifies property snapshots and every cold synchronous/asynchronous connection operation.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ConnectionContextExtensions_ExposePropertiesAndOperationsAsync()
+    {
+        var formatter = new MqttPacketFormatterAdapter(
+            MqttProtocolVersion.V500,
+            new MqttBufferWriter(InitialBufferSize, MaximumBufferSize));
+        var pipes = DuplexPipe.CreateConnectionPair(PipeOptions.Default, PipeOptions.Default);
+        var connectionContext = new DefaultConnectionContext { Transport = pipes.Transport };
+        using var connection = new MqttConnectionContext(formatter, connectionContext);
+
+        await AssertInitialPropertiesAsync(connection.Properties(), formatter);
+        _ = await connection.Connect().FirstAsync(Timeout);
+        _ = await connection.ConnectSignal().FirstAsync(Timeout);
+
+        _ = await connection.SendPacket(new MqttPingReqPacket()).FirstAsync(Timeout);
+        await DrainSentPacketAsync(pipes.Application);
+        _ = await connection.SendPacketSignal(new MqttPingRespPacket()).FirstAsync(Timeout);
+        await DrainSentPacketAsync(pipes.Application);
+
+        await pipes.Application.Output.WriteAsync(PingRequestBytes);
+        await Assert.That(await connection.ReceivePacket().FirstAsync(Timeout)).IsTypeOf<MqttPingReqPacket>();
+        await pipes.Application.Output.WriteAsync(PingResponseBytes);
+        await Assert.That(await connection.ReceivePacketSignal().FirstAsync(Timeout)).IsTypeOf<MqttPingRespPacket>();
+
+        await AssertPopulatedAndResetPropertiesAsync(connection);
+        await Assert.That(() => connection.SendPacket(null!)).Throws<ArgumentNullException>();
+        await Assert.That(() => connection.SendPacketSignal(null!)).Throws<ArgumentNullException>();
+        _ = await connection.Disconnect().FirstAsync(Timeout);
+        _ = await connection.DisconnectSignal().FirstAsync(Timeout);
+    }
+
+    /// <summary>Verifies an initial connection-property snapshot.</summary>
+    /// <param name="properties">The captured properties.</param>
+    /// <param name="formatter">The expected formatter.</param>
+    /// <returns>A task that represents the asynchronous assertions.</returns>
+    private static async Task AssertInitialPropertiesAsync(
+        MqttConnectionProperties properties,
+        MqttPacketFormatterAdapter formatter)
+    {
+        await Assert.That(properties.BytesReceived).IsEqualTo(0);
+        await Assert.That(properties.BytesSent).IsEqualTo(0);
+        await Assert.That(properties.ClientCertificate).IsNull();
+        await Assert.That(properties.IsSecureConnection).IsFalse();
+        await Assert.That(properties.LocalEndPoint).IsNull();
+        await Assert.That(properties.RemoteEndPoint).IsNull();
+        await Assert.That(properties.PacketFormatterAdapter).IsSameReferenceAs(formatter);
+    }
+
+    /// <summary>Verifies populated counters and their fluent reset.</summary>
+    /// <param name="connection">The connection under test.</param>
+    /// <returns>A task that represents the asynchronous assertions.</returns>
+    private static async Task AssertPopulatedAndResetPropertiesAsync(MqttConnectionContext connection)
+    {
+        var populated = connection.Properties();
+        await Assert.That(populated.BytesReceived).IsGreaterThan(0);
+        await Assert.That(populated.BytesSent).IsGreaterThan(0);
+        await Assert.That(connection.ResetConnectionStatistics()).IsSameReferenceAs(connection);
+        await Assert.That(connection.Properties().BytesReceived).IsEqualTo(0);
+        await Assert.That(connection.Properties().BytesSent).IsEqualTo(0);
+    }
+
+    /// <summary>Drains one encoded packet from a paired pipe.</summary>
+    /// <param name="pipe">The paired pipe endpoint.</param>
+    /// <returns>A task that represents the drain operation.</returns>
+    private static async Task DrainSentPacketAsync(IDuplexPipe pipe)
+    {
+        var result = await pipe.Input.ReadAsync();
+        pipe.Input.AdvanceTo(result.Buffer.End);
+    }
+
+    /// <summary>Returns the only registered MQTT server adapter.</summary>
+    /// <param name="provider">The service provider.</param>
+    /// <returns>The registered adapter.</returns>
+    private static IMqttServerAdapter GetOnlyAdapter(IServiceProvider provider)
+    {
+        IMqttServerAdapter? found = null;
+        foreach (var adapter in provider.GetServices<IMqttServerAdapter>())
+        {
+            if (found is not null)
+            {
+                throw new InvalidOperationException("Expected only one MQTT server adapter.");
+            }
+
+            found = adapter;
+        }
+
+        return found ?? throw new InvalidOperationException("Expected one MQTT server adapter.");
+    }
+
+    /// <summary>Creates services required to construct a hosted MQTT server.</summary>
+    /// <returns>The configured service collection.</returns>
+    private static ServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        _ = services.AddSingleton<IHostApplicationLifetime, TestHostApplicationLifetime>();
+        return services;
+    }
+
+    /// <summary>Provides a public endpoint-route builder for exercising endpoint extensions.</summary>
+    /// <param name="applicationBuilder">The application builder.</param>
+    private sealed class TestEndpointRouteBuilder(IApplicationBuilder applicationBuilder) : IEndpointRouteBuilder
+    {
+        /// <inheritdoc/>
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+
+        /// <inheritdoc/>
+        public IServiceProvider ServiceProvider => applicationBuilder.ApplicationServices;
+
+        /// <inheritdoc/>
+        public IApplicationBuilder CreateApplicationBuilder() => applicationBuilder.New();
+    }
+
+    /// <summary>Provides the host-lifetime contract required by the hosted server.</summary>
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime, IDisposable
+    {
+        /// <summary>Signals application start.</summary>
+        private readonly CancellationTokenSource _started = new();
+
+        /// <summary>Signals application stop completion.</summary>
+        private readonly CancellationTokenSource _stopped = new();
+
+        /// <summary>Signals application shutdown.</summary>
+        private readonly CancellationTokenSource _stopping = new();
+
+        /// <inheritdoc/>
+        public CancellationToken ApplicationStarted => _started.Token;
+
+        /// <inheritdoc/>
+        public CancellationToken ApplicationStopped => _stopped.Token;
+
+        /// <inheritdoc/>
+        public CancellationToken ApplicationStopping => _stopping.Token;
+
+        /// <inheritdoc/>
+        public void StopApplication() => _stopping.Cancel();
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _started.Dispose();
+            _stopped.Dispose();
+            _stopping.Dispose();
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Client.Tests/ClientCompleteSurfaceTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/ClientCompleteSurfaceTests.cs
@@ -1,0 +1,449 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Reflection;
+using MQTTnet.Packets;
+using MQTTnet.Protocol;
+using MQTTnet.Rx.Client.Tests.Helpers;
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using Signal = ReactiveUI.Primitives.Reactive.Signals.Signal;
+#else
+using Signal = ReactiveUI.Primitives.Signals.Signal;
+#endif
+
+namespace MQTTnet.Rx.Client.Tests;
+
+/// <summary>Exercises the complete direct and sequence-oriented MQTT client wrapper surface.</summary>
+public sealed class ClientCompleteSurfaceTests
+{
+    /// <summary>The non-routable test broker host stored in client option snapshots.</summary>
+    private const string BrokerHost = "localhost";
+
+    /// <summary>The number of direct publish operations exercised.</summary>
+    private const int ExpectedDirectPublishCount = 10;
+
+    /// <summary>The number of raw and fluent operation variants exercised.</summary>
+    private const int ExpectedOperationVariantCount = 4;
+
+    /// <summary>The number of sequence publish operations exercised.</summary>
+    private const int ExpectedSequencePublishCount = 2;
+
+    /// <summary>The expected successful auto-reconnect notification count.</summary>
+    private const int ExpectedReconnectNotificationCount = 2;
+
+    /// <summary>The retry limit used by the successful reconnect test.</summary>
+    private const int ReconnectAttemptLimit = 3;
+
+    /// <summary>The binary payload used by the publish overload tests.</summary>
+    private static readonly byte[] BinaryPayload = [1, 2];
+
+    /// <summary>The sequence payload used by the publish overload tests.</summary>
+    private static readonly byte[] SequencePayload = [3, 4];
+
+    /// <summary>The delay that keeps one reconnect handler active while a duplicate event arrives.</summary>
+    private static readonly TimeSpan DuplicateReconnectDelay = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>The delay cancelled by the cancellation-path reconnect test.</summary>
+    private static readonly TimeSpan CancellationReconnectDelay = TimeSpan.FromSeconds(1);
+
+    /// <summary>The maximum time allowed for a cold operation to produce its result.</summary>
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>Verifies every direct standard-client operation has synchronous and asynchronous forms.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task DirectClientConnectionAndPublishOperations_ExposePairedColdFormsAsync()
+    {
+        using var concreteClient = new MockMqttClient();
+        IMqttClient client = concreteClient;
+        var connectOptions = CreateClientOptions("direct-client");
+        var message = new MqttApplicationMessageBuilder().WithTopic("direct/message").WithPayload("one").Build();
+        var authenticationData = new MqttEnhancedAuthenticationExchangeData();
+
+        _ = await client.Connect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await client.Connect(static options => options.WithClientId("direct-configured").WithTcpServer(BrokerHost))
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObserveConnect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await client.ObserveConnect(static options => options.WithClientId("direct-observed").WithTcpServer(BrokerHost))
+            .FirstAsync(OperationTimeout);
+        _ = await client.Ping().FirstAsync(OperationTimeout);
+        _ = await client.ObservePing().FirstAsync(OperationTimeout);
+        _ = await client.Publish(message).FirstAsync(OperationTimeout);
+        _ = await client.Publish(static builder => builder.WithTopic("direct/configured").WithPayload("two"))
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObservePublish(message).FirstAsync(OperationTimeout);
+        _ = await client.ObservePublish(static builder => builder.WithTopic("direct/observed").WithPayload("three"))
+            .FirstAsync(OperationTimeout);
+        _ = await client.PublishBinary("direct/binary", BinaryPayload, MqttQualityOfServiceLevel.AtLeastOnce, true)
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObservePublishBinary("direct/binary-async", null, MqttQualityOfServiceLevel.AtMostOnce, false)
+            .FirstAsync(OperationTimeout);
+        var payload = new ReadOnlySequence<byte>(SequencePayload);
+        _ = await client.PublishSequence("direct/sequence", payload, MqttQualityOfServiceLevel.ExactlyOnce, false)
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObservePublishSequence(
+                "direct/sequence-async",
+                payload,
+                MqttQualityOfServiceLevel.AtLeastOnce,
+                true)
+            .FirstAsync(OperationTimeout);
+        _ = await client.PublishString("direct/string", "four", MqttQualityOfServiceLevel.AtMostOnce, false)
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObservePublishString("direct/string-async", null, MqttQualityOfServiceLevel.AtLeastOnce, true)
+            .FirstAsync(OperationTimeout);
+        _ = await client.Reconnect().FirstAsync(OperationTimeout);
+        _ = await client.ObserveReconnect().FirstAsync(OperationTimeout);
+        _ = await client.SendEnhancedAuthenticationExchangeData(authenticationData).FirstAsync(OperationTimeout);
+        _ = await client.ObserveSendEnhancedAuthenticationExchangeData(authenticationData).FirstAsync(OperationTimeout);
+
+        await Assert.That(concreteClient.PublishedMessages).Count().IsEqualTo(ExpectedDirectPublishCount);
+    }
+
+    /// <summary>Verifies every direct subscription and disconnection operation has paired cold forms.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task DirectClientSubscriptionAndDisconnectOperations_ExposePairedColdFormsAsync()
+    {
+        using var concreteClient = new MockMqttClient();
+        IMqttClient client = concreteClient;
+        var connectOptions = CreateClientOptions("direct-subscriptions");
+        var disconnectOptions = new MqttClientDisconnectOptionsBuilder().Build();
+        var subscribeOptions = new MqttClientSubscribeOptionsBuilder().WithTopicFilter("direct/#").Build();
+        var unsubscribeOptions = new MqttClientUnsubscribeOptionsBuilder().WithTopicFilter("direct/#").Build();
+
+        _ = await client.Subscribe(subscribeOptions).FirstAsync(OperationTimeout);
+        _ = await client.Subscribe(static builder => builder.WithTopicFilter("direct/configured/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObserveSubscribe(subscribeOptions).FirstAsync(OperationTimeout);
+        _ = await client.ObserveSubscribe(static builder => builder.WithTopicFilter("direct/observed/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await client.Unsubscribe(unsubscribeOptions).FirstAsync(OperationTimeout);
+        _ = await client.Unsubscribe(static builder => builder.WithTopicFilter("direct/configured/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObserveUnsubscribe(unsubscribeOptions).FirstAsync(OperationTimeout);
+        _ = await client.ObserveUnsubscribe(static builder => builder.WithTopicFilter("direct/observed/#"))
+            .FirstAsync(OperationTimeout);
+        var tryPing = await client.TryPing().FirstAsync(OperationTimeout);
+        var observeTryPing = await client.ObserveTryPing().FirstAsync(OperationTimeout);
+        var tryDisconnect = await client.TryDisconnect().FirstAsync(OperationTimeout);
+        var observeTryDisconnect = await client.ObserveTryDisconnect(
+                MqttClientDisconnectOptionsReason.NormalDisconnection,
+                "observed")
+            .FirstAsync(OperationTimeout);
+        _ = await client.Connect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await client.TryDisconnect(MqttClientDisconnectOptionsReason.NormalDisconnection, "direct")
+            .FirstAsync(OperationTimeout);
+        _ = await client.Connect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await client.ObserveTryDisconnect().FirstAsync(OperationTimeout);
+        _ = await client.Disconnect(disconnectOptions).FirstAsync(OperationTimeout);
+        _ = await client.Disconnect(static _ => { }).FirstAsync(OperationTimeout);
+        _ = await client.ObserveDisconnect(disconnectOptions).FirstAsync(OperationTimeout);
+        _ = await client.ObserveDisconnect(static _ => { }).FirstAsync(OperationTimeout);
+
+        await Assert.That(tryPing).IsTrue();
+        await Assert.That(observeTryPing).IsTrue();
+        await Assert.That(tryDisconnect).IsTrue();
+        await Assert.That(observeTryDisconnect).IsTrue();
+        await Assert.That(concreteClient.Subscriptions).Count().IsEqualTo(ExpectedOperationVariantCount);
+        await Assert.That(concreteClient.Unsubscriptions).Count().IsEqualTo(ExpectedOperationVariantCount);
+    }
+
+    /// <summary>Verifies every direct standard-client property has paired cold projections.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task DirectClientProperties_ExposeCompleteSnapshotsAsync()
+    {
+        using var concreteClient = new MockMqttClient();
+        IMqttClient client = concreteClient;
+        var options = CreateClientOptions("properties-client");
+        _ = await client.Connect(options).FirstAsync(OperationTimeout);
+
+        var immediate = client.Properties();
+        var property = await client.Property(static value => value.IsConnected).FirstAsync(OperationTimeout);
+        var observedProperty = await client.ObserveProperty(static value => value.Options).FirstAsync(OperationTimeout);
+        var snapshot = await client.PropertySnapshots().FirstAsync(OperationTimeout);
+        var observedSnapshot = await client.ObservePropertySnapshots().FirstAsync(OperationTimeout);
+        var connected = await client.IsConnectedValue().FirstAsync(OperationTimeout);
+        var observedConnected = await client.ObserveIsConnected().FirstAsync(OperationTimeout);
+        var optionsSnapshot = await client.OptionsSnapshot().FirstAsync(OperationTimeout);
+        var observedOptionsSnapshot = await client.ObserveOptionsSnapshot().FirstAsync(OperationTimeout);
+
+        await Assert.That(immediate.IsConnected).IsTrue();
+        await Assert.That(immediate.Options).IsSameReferenceAs(options);
+        await Assert.That(property).IsTrue();
+        await Assert.That(observedProperty).IsSameReferenceAs(options);
+        await Assert.That(snapshot).IsEqualTo(immediate);
+        await Assert.That(observedSnapshot).IsEqualTo(immediate);
+        await Assert.That(connected).IsTrue();
+        await Assert.That(observedConnected).IsTrue();
+        await Assert.That(optionsSnapshot).IsSameReferenceAs(options);
+        await Assert.That(observedOptionsSnapshot).IsSameReferenceAs(options);
+    }
+
+    /// <summary>Verifies raw options flow through both standard-client sequence variants.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ClientSequenceOperations_ExposeRawAndFluentOptionsAsync()
+    {
+        using var concreteClient = new MockMqttClient();
+        IMqttClient client = concreteClient;
+        var clients = Signal.Emit(client);
+        var asyncClients = SignalAsync.Return(client);
+        var connectOptions = CreateClientOptions("sequence-client");
+        var disconnectOptions = new MqttClientDisconnectOptionsBuilder().Build();
+        var message = new MqttApplicationMessageBuilder().WithTopic("sequence/message").Build();
+        var authenticationData = new MqttEnhancedAuthenticationExchangeData();
+        var subscribeOptions = new MqttClientSubscribeOptionsBuilder().WithTopicFilter("sequence/#").Build();
+        var unsubscribeOptions = new MqttClientUnsubscribeOptionsBuilder().WithTopicFilter("sequence/#").Build();
+
+        _ = await clients.Connect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await clients.Connect(static options => options.WithClientId("sequence-configured").WithTcpServer(BrokerHost))
+            .FirstAsync(OperationTimeout);
+        _ = await clients.Publish(message).FirstAsync(OperationTimeout);
+        _ = await clients.SendEnhancedAuthenticationExchangeData(authenticationData).FirstAsync(OperationTimeout);
+        _ = await clients.Subscribe(subscribeOptions).FirstAsync(OperationTimeout);
+        _ = await clients.Subscribe(static builder => builder.WithTopicFilter("sequence/configured/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await clients.Unsubscribe(unsubscribeOptions).FirstAsync(OperationTimeout);
+        _ = await clients.Unsubscribe(static builder => builder.WithTopicFilter("sequence/configured/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await clients.Disconnect(disconnectOptions).FirstAsync(OperationTimeout);
+        _ = await clients.Disconnect(static _ => { }).FirstAsync(OperationTimeout);
+
+        _ = await asyncClients.Connect(connectOptions).FirstAsync(OperationTimeout);
+        _ = await asyncClients.Connect(static options => options.WithClientId("sequence-observed").WithTcpServer(BrokerHost))
+            .FirstAsync(OperationTimeout);
+        _ = await asyncClients.Publish(message).FirstAsync(OperationTimeout);
+        _ = await asyncClients.SendEnhancedAuthenticationExchangeData(authenticationData).FirstAsync(OperationTimeout);
+        _ = await asyncClients.Subscribe(subscribeOptions).FirstAsync(OperationTimeout);
+        _ = await asyncClients.Subscribe(static builder => builder.WithTopicFilter("sequence/observed/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await asyncClients.Unsubscribe(unsubscribeOptions).FirstAsync(OperationTimeout);
+        _ = await asyncClients.Unsubscribe(static builder => builder.WithTopicFilter("sequence/observed/#"))
+            .FirstAsync(OperationTimeout);
+        _ = await asyncClients.Disconnect(disconnectOptions).FirstAsync(OperationTimeout);
+        _ = await asyncClients.Disconnect(static _ => { }).FirstAsync(OperationTimeout);
+
+        await Assert.That(concreteClient.PublishedMessages).Count().IsEqualTo(ExpectedSequencePublishCount);
+        await Assert.That(concreteClient.Subscriptions).Count().IsEqualTo(ExpectedOperationVariantCount);
+        await Assert.That(concreteClient.Unsubscriptions).Count().IsEqualTo(ExpectedOperationVariantCount);
+    }
+
+    /// <summary>Verifies every resilient-client operation and property has paired projections.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ResilientClient_ExposesCompletePairedSurfaceAsync()
+    {
+        using var concreteClient = new MockResilientMqttClient();
+        var client = concreteClient;
+        var options = CreateResilientOptions("resilient-client");
+        var message = new MqttApplicationMessageBuilder().WithTopic("resilient/message").Build();
+        var managedMessage = new ResilientMqttApplicationMessage { ApplicationMessage = message };
+        MqttTopicFilter[] filters = [new MqttTopicFilterBuilder().WithTopic("resilient/#").Build()];
+        string[] topics = ["resilient/#"];
+
+        _ = await client.Start(options).FirstAsync(OperationTimeout);
+        _ = await client.Stop().FirstAsync(OperationTimeout);
+        _ = await client.Start(static builder =>
+                builder.WithClientOptions(CreateClientOptions("resilient-configured")))
+            .FirstAsync(OperationTimeout);
+        _ = await client.Enqueue(message).FirstAsync(OperationTimeout);
+        _ = await client.Enqueue(managedMessage).FirstAsync(OperationTimeout);
+        _ = await client.Ping().FirstAsync(OperationTimeout);
+        _ = await client.Subscribe(filters).FirstAsync(OperationTimeout);
+        _ = await client.Unsubscribe(topics).FirstAsync(OperationTimeout);
+        _ = await client.Stop(false).FirstAsync(OperationTimeout);
+        _ = await client.ObserveStart(options).FirstAsync(OperationTimeout);
+        _ = await client.ObserveStop().FirstAsync(OperationTimeout);
+        _ = await client.ObserveStart(static builder =>
+                builder.WithClientOptions(CreateClientOptions("resilient-observed")))
+            .FirstAsync(OperationTimeout);
+        _ = await client.ObserveEnqueue(message).FirstAsync(OperationTimeout);
+        _ = await client.ObserveEnqueue(managedMessage).FirstAsync(OperationTimeout);
+        _ = await client.ObservePing().FirstAsync(OperationTimeout);
+        _ = await client.ObserveSubscribe(filters).FirstAsync(OperationTimeout);
+        _ = await client.ObserveUnsubscribe(topics).FirstAsync(OperationTimeout);
+        _ = await client.ObserveStop(false).FirstAsync(OperationTimeout);
+
+        var immediate = client.Properties();
+        var property = await client.Property(static value => value.IsStarted).FirstAsync(OperationTimeout);
+        var observedProperty = await client.ObserveProperty(static value => value.InternalClient)
+            .FirstAsync(OperationTimeout);
+        var snapshot = await client.PropertySnapshots().FirstAsync(OperationTimeout);
+        var observedSnapshot = await client.ObservePropertySnapshots().FirstAsync(OperationTimeout);
+        var changed = new TaskCompletionSource<SubscriptionsChangedEventArgs>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var subscription = client.SubscriptionsChanged().Subscribe(value => _ = changed.TrySetResult(value));
+        await concreteClient.SimulateSubscriptionsChangedAsync();
+        var eventArgs = await changed.Task.WaitAsync(OperationTimeout);
+
+        await Assert.That(immediate.InternalClient).IsSameReferenceAs(client.InternalClient);
+        await Assert.That(property).IsFalse();
+        await Assert.That(observedProperty).IsSameReferenceAs(client.InternalClient);
+        await Assert.That(snapshot).IsEqualTo(immediate);
+        await Assert.That(observedSnapshot).IsEqualTo(immediate);
+        await Assert.That(eventArgs.SubscribeResult).IsEmpty();
+        await Assert.That(eventArgs.UnsubscribeResult).IsEmpty();
+    }
+
+    /// <summary>Verifies asynchronous auto reconnect retries, emits, and reports exhausted retry policies.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task AsyncAutoReconnect_HandlesSuccessAndExhaustionAsync()
+    {
+        using var successfulClient = new MockMqttClient();
+        _ = await successfulClient.ConnectAsync(CreateClientOptions("auto-success"));
+        successfulClient.ReconnectFailuresRemaining = 1;
+        IObservableAsync<IMqttClient> successfulSource = SignalAsync.Return<IMqttClient>(successfulClient);
+        _ = successfulSource.WithAutoReconnect();
+        _ = successfulSource.WithAutoReconnect(TimeSpan.Zero);
+        var emitted = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var count = 0;
+        await using var successfulSubscription = await successfulSource
+            .WithAutoReconnect(TimeSpan.Zero, ReconnectAttemptLimit)
+            .SubscribeAsync(
+                (value, cancellationToken) =>
+                {
+                    GC.KeepAlive(value);
+                    GC.KeepAlive(cancellationToken);
+                    if (Interlocked.Increment(ref count) == ExpectedReconnectNotificationCount)
+                    {
+                        _ = emitted.TrySetResult(count);
+                    }
+
+                    return ValueTask.CompletedTask;
+                },
+                CancellationToken.None);
+        await successfulClient.SimulateDisconnectedAsync();
+        var observedCount = await emitted.Task.WaitAsync(OperationTimeout);
+
+        using var failingClient = new MockMqttClient { ReconnectFailuresRemaining = ReconnectAttemptLimit };
+        IObservableAsync<IMqttClient> failingSource = SignalAsync.Return<IMqttClient>(failingClient);
+        var failure = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var failingSubscription = await failingSource
+            .WithAutoReconnect(TimeSpan.Zero, 1)
+            .SubscribeAsync(
+                static (_, _) => ValueTask.CompletedTask,
+                (exception, cancellationToken) =>
+                {
+                    GC.KeepAlive(cancellationToken);
+                    _ = failure.TrySetResult(exception);
+                    return ValueTask.CompletedTask;
+                },
+                static _ => ValueTask.CompletedTask,
+                CancellationToken.None);
+        await failingClient.SimulateDisconnectedAsync();
+        var observedFailure = await failure.Task.WaitAsync(OperationTimeout);
+
+        await Assert.That(observedCount).IsEqualTo(ExpectedReconnectNotificationCount);
+        await Assert.That(successfulClient.ConnectCount).IsEqualTo(ReconnectAttemptLimit);
+        await Assert.That(observedFailure).IsTypeOf<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies duplicate disconnect events are serialized and cancellation stops a pending reconnect.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task AsyncAutoReconnect_SerializesDuplicatesAndHonorsCancellationAsync()
+    {
+        using var duplicateClient = new MockMqttClient();
+        _ = await duplicateClient.ConnectAsync(CreateClientOptions("auto-duplicate"));
+        duplicateClient.ReconnectFailuresRemaining = 1;
+        var duplicateNotifications = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var notificationCount = 0;
+        await using var duplicateSubscription = await SignalAsync.Return<IMqttClient>(duplicateClient)
+            .WithAutoReconnect(DuplicateReconnectDelay)
+            .SubscribeAsync(
+                (value, cancellationToken) =>
+                {
+                    GC.KeepAlive(value);
+                    GC.KeepAlive(cancellationToken);
+                    if (Interlocked.Increment(ref notificationCount) == ExpectedReconnectNotificationCount)
+                    {
+                        _ = duplicateNotifications.TrySetResult();
+                    }
+
+                    return ValueTask.CompletedTask;
+                },
+                CancellationToken.None);
+        await Task.WhenAll(duplicateClient.SimulateDisconnectedAsync(), duplicateClient.SimulateDisconnectedAsync());
+        await duplicateNotifications.Task.WaitAsync(OperationTimeout);
+
+        using var cancelledClient = new MockMqttClient();
+        _ = await cancelledClient.ConnectAsync(CreateClientOptions("auto-cancelled"));
+        using var cancellation = new CancellationTokenSource();
+        await using var cancelledSubscription = await SignalAsync.Return<IMqttClient>(cancelledClient)
+            .WithAutoReconnect(CancellationReconnectDelay, 1)
+            .SubscribeAsync(static (_, _) => ValueTask.CompletedTask, cancellation.Token);
+        var disconnect = cancelledClient.SimulateDisconnectedAsync();
+        await Task.Yield();
+        await cancellation.CancelAsync();
+        await disconnect;
+
+        await Assert.That(notificationCount).IsEqualTo(ExpectedReconnectNotificationCount);
+        await Assert.That(cancelledClient.IsConnected).IsFalse();
+    }
+
+    /// <summary>Verifies factory observer rejection releases the rejected lease before retrying.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task FactoryObserverRejection_ReleasesRejectedLeaseAsync()
+    {
+        await Assert.That(static () =>
+            {
+                using var subscription = TestClientCreate.MqttClient().Subscribe(static value =>
+                {
+                    GC.KeepAlive(value);
+                    throw new InvalidOperationException("Reject the synchronous lease.");
+                });
+            })
+            .Throws<InvalidOperationException>();
+
+        await ExerciseClientNotifyObserverFailureAsync();
+    }
+
+    /// <summary>Creates standard client options for a test client.</summary>
+    /// <param name="clientId">The client identifier.</param>
+    /// <returns>The configured options.</returns>
+    private static MqttClientOptions CreateClientOptions(string clientId) =>
+        new MqttClientOptionsBuilder().WithClientId(clientId).WithTcpServer(BrokerHost).Build();
+
+    /// <summary>Creates resilient-client options for a test client.</summary>
+    /// <param name="clientId">The client identifier.</param>
+    /// <returns>The configured options.</returns>
+    private static ResilientMqttClientOptions CreateResilientOptions(string clientId) =>
+        new ResilientMqttClientOptionsBuilder().WithClientOptions(CreateClientOptions(clientId)).Build();
+
+    /// <summary>Invokes the factory notification boundary with a rejecting asynchronous observer.</summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    private static async Task ExerciseClientNotifyObserverFailureAsync()
+    {
+        var lifetimeDefinition = typeof(TestClientCreate).GetNestedType(
+            "SharedClientLifetime`1",
+            BindingFlags.NonPublic) ?? throw new InvalidOperationException("Client lifetime type was not found.");
+        var lifetimeType = lifetimeDefinition.MakeGenericType(typeof(IMqttClient));
+        var lifetime = Activator.CreateInstance(
+            lifetimeType,
+            (Func<IMqttClient>)(static () => new MockMqttClient())) ??
+            throw new InvalidOperationException("Client lifetime was not created.");
+        var acquire = lifetimeType.GetMethod("Acquire", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Client acquisition method was not found.");
+        var lease = acquire.Invoke(lifetime, null) ?? throw new InvalidOperationException("Client lease was not acquired.");
+        var notifyDefinition = typeof(TestClientCreate).GetMethod(
+            "NotifyObserverAsync",
+            BindingFlags.Static | BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Client notification method was not found.");
+        var notify = notifyDefinition.MakeGenericMethod(typeof(IMqttClient));
+        var observer = new ControlledAsyncObserver<IMqttClient>(new InvalidOperationException("Reject client lease."));
+        var operation = notify.Invoke(null, [observer, lease, CancellationToken.None]) ??
+            throw new InvalidOperationException("Client notification operation was not created.");
+        var asTask = operation.GetType().GetMethod("AsTask", BindingFlags.Instance | BindingFlags.Public) ??
+            throw new InvalidOperationException("Client notification task adapter was not found.");
+        var task = (Task)(asTask.Invoke(operation, null) ??
+            throw new InvalidOperationException("Client notification task was not created."));
+
+        await Assert.That(async () => await task).Throws<InvalidOperationException>();
+    }
+}

--- a/src/MQTTnet.Rx.Client.Tests/ClientConfigurationCoverageTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/ClientConfigurationCoverageTests.cs
@@ -153,8 +153,8 @@ public sealed class ClientConfigurationCoverageTests
         await using var disconnectedAsyncSubscription = await client.ObserveDisconnected().SubscribeAsync(
             static (_, _) => ValueTask.CompletedTask,
             CancellationToken.None);
-        using var inspectionSubscription = client.InspectPackage().Subscribe(static _ => { });
-        await using var inspectionAsyncSubscription = await client.ObserveInspectPackage().SubscribeAsync(
+        using var inspectionSubscription = client.InspectPacket().Subscribe(static _ => { });
+        await using var inspectionAsyncSubscription = await client.ObserveInspectPacket().SubscribeAsync(
             static (_, _) => ValueTask.CompletedTask,
             CancellationToken.None);
 

--- a/src/MQTTnet.Rx.Client.Tests/ClientFactoryCoverageClosureTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/ClientFactoryCoverageClosureTests.cs
@@ -41,8 +41,8 @@ public sealed class ClientFactoryCoverageClosureTests
         var disconnectedAsync = await client.ObserveDisconnected().SubscribeAsync(
             static (_, _) => ValueTask.CompletedTask,
             CancellationToken.None);
-        using var inspection = client.InspectPackage().Subscribe(static _ => { });
-        var inspectionAsync = await client.ObserveInspectPackage().SubscribeAsync(
+        using var inspection = client.InspectPacket().Subscribe(static _ => { });
+        var inspectionAsync = await client.ObserveInspectPacket().SubscribeAsync(
             static (_, _) => ValueTask.CompletedTask,
             CancellationToken.None);
 

--- a/src/MQTTnet.Rx.Client.Tests/FinalClientCreateCoverageClosureTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/FinalClientCreateCoverageClosureTests.cs
@@ -82,7 +82,7 @@ public sealed class FinalClientCreateCoverageClosureTests
             _ => disconnectedCount++,
             cancellation.Token);
         var inspected = await SubscribeDirectAsync(
-            client.ObserveInspectPackage(),
+            client.ObserveInspectPacket(),
             cancellationToken: cancellation.Token);
 
         await client.SimulateMessageReceivedAsync("coverage/create", "payload");

--- a/src/MQTTnet.Rx.Client.Tests/Helpers/LiveMqttBroker.cs
+++ b/src/MQTTnet.Rx.Client.Tests/Helpers/LiveMqttBroker.cs
@@ -79,6 +79,9 @@ public sealed class LiveMqttBroker : IAsyncDisposable
     /// <summary>Gets the first exception observed during deterministic teardown, if any.</summary>
     public Exception? TeardownException { get; private set; }
 
+    /// <summary>Gets the hosted server for broker-surface integration tests.</summary>
+    internal MqttServer Server => _server;
+
     /// <summary>Starts a real MQTTnet server on an ephemeral loopback port.</summary>
     /// <returns>The started live MQTT broker fixture.</returns>
     public static Task<LiveMqttBroker> StartAsync() => StartAsync(CancellationToken.None);

--- a/src/MQTTnet.Rx.Client.Tests/Helpers/MockResilientMqttClient.cs
+++ b/src/MQTTnet.Rx.Client.Tests/Helpers/MockResilientMqttClient.cs
@@ -296,6 +296,15 @@ public sealed class MockResilientMqttClient : IResilientMqttClient
         await InvokeHandlersAsync(_disconnectedHandlers, args).ConfigureAwait(false);
     }
 
+    /// <summary>Raises the subscriptions-changed event.</summary>
+    /// <returns>A task that completes when event handlers have run.</returns>
+    public async Task SimulateSubscriptionsChangedAsync()
+    {
+        var args = new SubscriptionsChangedEventArgs([], []);
+        SubscriptionsChangedEvent?.Invoke(this, args);
+        await InvokeHandlersAsync(_subscriptionsChangedHandlers, args).ConfigureAwait(false);
+    }
+
     /// <summary>Raises the application message processed event.</summary>
     /// <returns>A task that completes when event handlers have run.</returns>
     public async Task SimulateApplicationMessageProcessedAsync()

--- a/src/MQTTnet.Rx.Client.Tests/MQTTnet.Rx.Client.Tests.csproj
+++ b/src/MQTTnet.Rx.Client.Tests/MQTTnet.Rx.Client.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MQTTnet.Rx.ABPlc\MQTTnet.Rx.ABPlc.csproj" />
+    <ProjectReference Include="..\MQTTnet.Rx.AspNetCore\MQTTnet.Rx.AspNetCore.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Client\MQTTnet.Rx.Client.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Mitsubishi\MQTTnet.Rx.Mitsubishi.csproj" />
     <ProjectReference Include="..\MQTTnet.Rx.Modbus\MQTTnet.Rx.Modbus.csproj" />

--- a/src/MQTTnet.Rx.Client.Tests/ServerCompleteSurfaceTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/ServerCompleteSurfaceTests.cs
@@ -1,0 +1,642 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Reflection;
+using MQTTnet.Adapter;
+using MQTTnet.Packets;
+using MQTTnet.Rx.Client.Tests.Helpers;
+#if REACTIVE_SHIM
+using MQTTnet.Rx.Server.Reactive;
+#else
+using MQTTnet.Rx.Server;
+#endif
+using MQTTnet.Server;
+using MQTTnet.Server.EnhancedAuthentication;
+using NSubstitute;
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using ServerCreate = MQTTnet.Rx.Server.Reactive.Create;
+using Signal = ReactiveUI.Primitives.Reactive.Signals.Signal;
+#else
+using ServerCreate = MQTTnet.Rx.Server.Create;
+using Signal = ReactiveUI.Primitives.Signals.Signal;
+#endif
+
+namespace MQTTnet.Rx.Client.Tests;
+
+/// <summary>Exercises the complete direct MQTT broker wrapper surface.</summary>
+[NotInParallel]
+public sealed class ServerCompleteSurfaceTests
+{
+    /// <summary>The enhanced-authentication method used by the adapter test.</summary>
+    private const string AuthenticationMethodValue = "test-authentication";
+
+    /// <summary>The value used for server and session item tests.</summary>
+    private const string SessionItemValue = "value";
+
+    /// <summary>The expected lifecycle state count after six start-stop cycles.</summary>
+    private const int ExpectedLifecycleStateCount = 13;
+
+    /// <summary>The number of connected clients hosted by the live fixture.</summary>
+    private const int LiveClientCount = 2;
+
+    /// <summary>The maximum time allowed for a cold operation to produce its result.</summary>
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>Verifies direct, sequence, builder, and property configuration surfaces.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServerConfigurationAndProperties_ExposeCompleteFluentSurfaceAsync()
+    {
+        using var server = CreateServer();
+        var configured = false;
+        var sameServer = server
+            .WithAcceptNewConnections(false)
+            .WithServerSessionItem("one", SessionItemValue)
+            .WithoutServerSessionItem("missing")
+            .ConfigureServer(value =>
+            {
+                configured = true;
+                value.AcceptNewConnections = true;
+            });
+        _ = server.Properties();
+        _ = server.WithoutServerSessionItem("one").WithServerSessionItem("two", SessionItemValue);
+        _ = server.ClearServerSessionItems();
+        var syncConfigured = await Signal.Emit(server)
+            .ConfigureServer(static value => value.AcceptNewConnections = false)
+            .FirstAsync(OperationTimeout);
+        var asyncConfigured = await SignalAsync.Return(server)
+            .ConfigureServer(static value => value.AcceptNewConnections = true)
+            .FirstAsync(OperationTimeout);
+
+        var immediate = server.Properties();
+        var property = await server.Property(static value => value.IsStarted).FirstAsync(OperationTimeout);
+        var observedProperty = await server.ObserveProperty(static value => value.AcceptNewConnections)
+            .FirstAsync(OperationTimeout);
+        var snapshot = await server.PropertySnapshots().FirstAsync(OperationTimeout);
+        var observedSnapshot = await server.ObservePropertySnapshots().FirstAsync(OperationTimeout);
+        var accepts = await server.AcceptNewConnectionsValue().FirstAsync(OperationTimeout);
+        var observedAccepts = await server.ObserveAcceptNewConnections().FirstAsync(OperationTimeout);
+        var items = await server.ServerSessionItemsSnapshot().FirstAsync(OperationTimeout);
+        var observedItems = await server.ObserveServerSessionItemsSnapshot().FirstAsync(OperationTimeout);
+
+        await Assert.That(sameServer).IsSameReferenceAs(server);
+        await Assert.That(syncConfigured).IsSameReferenceAs(server);
+        await Assert.That(asyncConfigured).IsSameReferenceAs(server);
+        await Assert.That(configured).IsTrue();
+        await Assert.That(immediate.IsStarted).IsFalse();
+        await Assert.That(property).IsFalse();
+        await Assert.That(observedProperty).IsTrue();
+        await Assert.That(snapshot.AcceptNewConnections).IsEqualTo(immediate.AcceptNewConnections);
+        await Assert.That(observedSnapshot.IsStarted).IsEqualTo(immediate.IsStarted);
+        await Assert.That(snapshot.ServerSessionItems).IsEmpty();
+        await Assert.That(observedSnapshot.ServerSessionItems).IsEmpty();
+        await Assert.That(accepts).IsTrue();
+        await Assert.That(observedAccepts).IsTrue();
+        await Assert.That(items).IsEmpty();
+        await Assert.That(observedItems).IsEmpty();
+    }
+
+    /// <summary>Verifies every server options builder exposes its underlying option object fluently.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServerOptionBuilders_ExposeUnderlyingConfigurationAsync()
+    {
+        var factory = new MqttServerFactory();
+        var disconnectConfigured = false;
+        var serverConfigured = false;
+        var stopConfigured = false;
+        var disconnectBuilder = new MqttServerClientDisconnectOptionsBuilder();
+        var serverBuilder = factory.CreateServerOptionsBuilder().WithoutDefaultEndpoint();
+        var stopBuilder = new MqttServerStopOptionsBuilder();
+
+        var sameDisconnectBuilder = disconnectBuilder.ConfigureOptions(options =>
+        {
+            disconnectConfigured = true;
+            GC.KeepAlive(options);
+        });
+        var sameServerBuilder = serverBuilder.ConfigureOptions(options =>
+        {
+            serverConfigured = true;
+            GC.KeepAlive(options);
+        });
+        var sameStopBuilder = stopBuilder.ConfigureOptions(options =>
+        {
+            stopConfigured = true;
+            GC.KeepAlive(options);
+        });
+
+        await Assert.That(sameDisconnectBuilder).IsSameReferenceAs(disconnectBuilder);
+        await Assert.That(sameServerBuilder).IsSameReferenceAs(serverBuilder);
+        await Assert.That(sameStopBuilder).IsSameReferenceAs(stopBuilder);
+        await Assert.That(disconnectConfigured).IsTrue();
+        await Assert.That(serverConfigured).IsTrue();
+        await Assert.That(stopConfigured).IsTrue();
+    }
+
+    /// <summary>Verifies lifecycle state and every paired start-stop operation.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServerLifecycle_EmitsStateForEveryOperationFormAsync()
+    {
+        using var server = CreateServer();
+        var synchronousStates = new List<bool>();
+        var asynchronousStates = new List<bool>();
+        using var synchronousSubscription = server.IsStartedChanges().Subscribe(synchronousStates.Add);
+        await using var asynchronousSubscription = await server.ObserveIsStartedChanges().SubscribeAsync(
+            (value, cancellationToken) =>
+            {
+                GC.KeepAlive(cancellationToken);
+                asynchronousStates.Add(value);
+                return ValueTask.CompletedTask;
+            },
+            CancellationToken.None);
+
+        await ExerciseLifecycleOperationsAsync(server);
+        synchronousSubscription.Dispose();
+        synchronousSubscription.Dispose();
+        await asynchronousSubscription.DisposeAsync();
+        await asynchronousSubscription.DisposeAsync();
+
+        await Assert.That(synchronousStates).Count().IsEqualTo(ExpectedLifecycleStateCount);
+        await Assert.That(asynchronousStates).Count().IsEqualTo(ExpectedLifecycleStateCount);
+        await Assert.That(synchronousStates[0]).IsFalse();
+        await Assert.That(asynchronousStates[0]).IsFalse();
+    }
+
+    /// <summary>Verifies every broker data and client-control operation in both reactive forms.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task LiveServerOperations_ExposeCompletePairedSurfaceAsync()
+    {
+        await using var broker = await LiveMqttBroker.StartAsync();
+        _ = await broker.ConnectClientsAsync();
+        var server = broker.Server;
+        var firstRetained = CreateMessage("server/retained-one", true);
+        var secondRetained = CreateMessage("server/retained-two", true);
+        var filters = new List<MqttTopicFilter> { new MqttTopicFilterBuilder().WithTopic("server/#").Build() };
+        var topics = new List<string> { "server/#" };
+
+        _ = await server.UpdateRetainedMessage(firstRetained).FirstAsync(OperationTimeout);
+        _ = await server.ObserveUpdateRetainedMessage(secondRetained).FirstAsync(OperationTimeout);
+        var retained = await server.GetRetainedMessage(firstRetained.Topic).FirstAsync(OperationTimeout);
+        var observedRetained = await server.ObserveRetainedMessage(secondRetained.Topic).FirstAsync(OperationTimeout);
+        var retainedMessages = await server.GetRetainedMessages().FirstAsync(OperationTimeout);
+        var observedRetainedMessages = await server.ObserveRetainedMessages().FirstAsync(OperationTimeout);
+        var clients = await server.GetClients().FirstAsync(OperationTimeout);
+        var observedClients = await server.ObserveClients().FirstAsync(OperationTimeout);
+        var session = await server.GetSession(broker.BridgeClientId).FirstAsync(OperationTimeout);
+        var observedSession = await server.ObserveSession(broker.ProbeClientId).FirstAsync(OperationTimeout);
+        var sessions = await server.GetSessions().FirstAsync(OperationTimeout);
+        var observedSessions = await server.ObserveSessions().FirstAsync(OperationTimeout);
+        _ = await server.SubscribeClient(broker.BridgeClientId, filters).FirstAsync(OperationTimeout);
+        _ = await server.SubscribeClient(
+                broker.ProbeClientId,
+                static builder => builder.WithTopic("server/configured"))
+            .FirstAsync(OperationTimeout);
+        _ = await server.ObserveSubscribeClient(broker.BridgeClientId, filters).FirstAsync(OperationTimeout);
+        _ = await server.ObserveSubscribeClient(
+                broker.ProbeClientId,
+                static builder => builder.WithTopic("server/observed"))
+            .FirstAsync(OperationTimeout);
+        _ = await server.UnsubscribeClient(broker.BridgeClientId, topics).FirstAsync(OperationTimeout);
+        _ = await server.ObserveUnsubscribeClient(broker.ProbeClientId, topics).FirstAsync(OperationTimeout);
+
+        await Assert.That(retained.Topic).IsEqualTo(firstRetained.Topic);
+        await Assert.That(observedRetained.Topic).IsEqualTo(secondRetained.Topic);
+        await Assert.That(retainedMessages).Count().IsEqualTo(LiveClientCount);
+        await Assert.That(observedRetainedMessages).Count().IsEqualTo(LiveClientCount);
+        await Assert.That(clients).Count().IsEqualTo(LiveClientCount);
+        await Assert.That(observedClients).Count().IsEqualTo(LiveClientCount);
+        await Assert.That(session.Id).IsEqualTo(broker.BridgeClientId);
+        await Assert.That(observedSession.Id).IsEqualTo(broker.ProbeClientId);
+        await Assert.That(sessions).Count().IsEqualTo(LiveClientCount);
+        await Assert.That(observedSessions).Count().IsEqualTo(LiveClientCount);
+
+        await ExerciseMessageAndRetainedOperationsAsync(server, firstRetained);
+        await ExerciseServerDisconnectOperationsAsync(broker);
+    }
+
+    /// <summary>Verifies client and session statuses expose all properties, configuration, and operations.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task LiveStatuses_ExposeCompletePairedSurfaceAsync()
+    {
+        await using var broker = await LiveMqttBroker.StartAsync();
+        _ = await broker.ConnectClientsAsync();
+        var statuses = await broker.Server.GetClients().FirstAsync(OperationTimeout);
+        var sessions = await broker.Server.GetSessions().FirstAsync(OperationTimeout);
+        var client = FindClientStatus(statuses, broker.BridgeClientId);
+        var secondClient = FindClientStatus(statuses, broker.ProbeClientId);
+        var session = FindSessionStatus(sessions, broker.BridgeClientId);
+        var secondSession = FindSessionStatus(sessions, broker.ProbeClientId);
+
+        await ExerciseClientStatusAsync(client, session);
+        await ExerciseSessionStatusAsync(session, "server/session-one");
+        await ExerciseSessionStatusAsync(secondSession, "server/session-two");
+        _ = await client.Disconnect(new MqttServerClientDisconnectOptionsBuilder().Build())
+            .FirstAsync(OperationTimeout);
+        _ = await client.Disconnect(static _ => { }).FirstAsync(OperationTimeout);
+        _ = await secondClient.ObserveDisconnect(new MqttServerClientDisconnectOptionsBuilder().Build())
+            .FirstAsync(OperationTimeout);
+        _ = await secondClient.ObserveDisconnect(static _ => { }).FirstAsync(OperationTimeout);
+        await WaitUntilAsync(() => !broker.BridgeClient.IsConnected && !broker.ProbeClient.IsConnected);
+        _ = session.Properties();
+        _ = secondSession.Properties();
+        _ = await session.Delete().FirstAsync(OperationTimeout);
+        _ = await secondSession.ObserveDelete().FirstAsync(OperationTimeout);
+
+        await Assert.That(broker.BridgeClient.IsConnected).IsFalse();
+        await Assert.That(broker.ProbeClient.IsConnected).IsFalse();
+    }
+
+    /// <summary>Verifies enhanced authentication is exposed through both cold reactive forms.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ValidationEnhancedAuthentication_ExposesPairedColdFormsAsync()
+    {
+        var adapter = Substitute.For<IMqttChannelAdapter>();
+        _ = adapter.SendPacketAsync(Arg.Any<MqttPacket>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        _ = adapter.ReceivePacketAsync(Arg.Any<CancellationToken>()).Returns(
+            Task.FromResult<MqttPacket>(new MqttAuthPacket { AuthenticationMethod = AuthenticationMethodValue }));
+        var connectPacket = new MqttConnectPacket { AuthenticationMethod = AuthenticationMethodValue };
+        var eventArgs = new ValidatingConnectionEventArgs(
+            connectPacket,
+            adapter,
+            new Hashtable(),
+            CancellationToken.None);
+        var options = new ExchangeEnhancedAuthenticationOptions();
+
+        var result = await eventArgs.ExchangeEnhancedAuthentication(options).FirstAsync(OperationTimeout);
+        var observedResult = await eventArgs.ObserveExchangeEnhancedAuthentication(options)
+            .FirstAsync(OperationTimeout);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(observedResult).IsNotNull();
+    }
+
+    /// <summary>Verifies lifecycle and factory observer failures clean up their acquired resources.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ObserverRejection_CleansUpLifecycleAndFactoryResourcesAsync()
+    {
+        using var server = CreateServer();
+        await Assert.That(() =>
+            {
+                using var subscription = server.IsStartedChanges().Subscribe(
+                    static _ => throw new InvalidOperationException("Reject state."));
+            })
+            .Throws<InvalidOperationException>();
+        var observer = new ControlledAsyncObserver<bool>(new InvalidOperationException("Reject async state."));
+        await Assert.That(async () =>
+                _ = await server.ObserveIsStartedChanges().SubscribeAsync(observer, CancellationToken.None))
+            .Throws<InvalidOperationException>();
+        await ExerciseServerNotifyObserverFailureAsync(server);
+    }
+
+    /// <summary>Verifies state subscriptions deduplicate notifications and dispose idempotently.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task LifecycleStateSubscriptions_HandleDeduplicationAndIdempotenceAsync()
+    {
+        using var server = CreateServer();
+        var owner = typeof(MqttServerPropertyExtensions);
+        var synchronousType = owner.GetNestedType("ServerStateSubscription", BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Synchronous server state subscription type was not found.");
+        var synchronousObserver = Substitute.For<IObserver<bool>>();
+        var synchronous = Activator.CreateInstance(
+            synchronousType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            [server, synchronousObserver],
+            culture: null) ?? throw new InvalidOperationException("Synchronous state subscription was not created.");
+        var synchronousPublish = synchronousType.GetMethod("Publish", BindingFlags.Instance | BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Synchronous publish method was not found.");
+        _ = synchronousPublish.Invoke(synchronous, [false]);
+        ((IDisposable)synchronous).Dispose();
+        ((IDisposable)synchronous).Dispose();
+        _ = synchronousPublish.Invoke(synchronous, [true]);
+
+        var asynchronousType = owner.GetNestedType("ServerStateAsyncSubscription", BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Asynchronous server state subscription type was not found.");
+        var asynchronousObserver = Substitute.For<IObserverAsync<bool>>();
+        var asynchronous = Activator.CreateInstance(
+            asynchronousType,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            [server, asynchronousObserver, CancellationToken.None],
+            culture: null) ?? throw new InvalidOperationException("Asynchronous state subscription was not created.");
+        await InvokeValueTaskAsync(asynchronousType, asynchronous, "InitializeAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        await InvokeValueTaskAsync(asynchronousType, asynchronous, "PublishAsync", BindingFlags.Instance | BindingFlags.NonPublic, false);
+        await ((IAsyncDisposable)asynchronous).DisposeAsync();
+        await ((IAsyncDisposable)asynchronous).DisposeAsync();
+        await InvokeValueTaskAsync(asynchronousType, asynchronous, "PublishAsync", BindingFlags.Instance | BindingFlags.NonPublic, true);
+
+        synchronousObserver.Received(1).OnNext(false);
+        await asynchronousObserver.Received(1).OnNextAsync(false, Arg.Any<CancellationToken>());
+        await Assert.That(server.IsStarted).IsFalse();
+    }
+
+    /// <summary>Verifies server sessions always release their owner when resource or release cleanup fails.</summary>
+    /// <returns>A task that represents the asynchronous test.</returns>
+    [Test]
+    public async Task ServerSessions_ReleaseOwnerAcrossCleanupFailuresAsync()
+    {
+        using var server = CreateServer();
+        var releaseFailure = new InvalidOperationException("Release failed.");
+        var resourceFailure = new InvalidOperationException("Resource failed.");
+        var releasedAfterResourceFailure = false;
+        var releaseOnly = CreateServerSession(
+            server,
+            () => ValueTask.FromException(releaseFailure));
+        var resourceOnly = CreateServerSession(
+            server,
+            () =>
+            {
+                releasedAfterResourceFailure = true;
+                return ValueTask.CompletedTask;
+            });
+        var resource = Substitute.For<IDisposable>();
+        resource.When(static value => value.Dispose()).Do(_ => throw resourceFailure);
+        resourceOnly.Add(resource);
+        var both = CreateServerSession(server, () => ValueTask.FromException(releaseFailure));
+        var secondResource = Substitute.For<IDisposable>();
+        secondResource.When(static value => value.Dispose()).Do(_ => throw resourceFailure);
+        both.Add(secondResource);
+
+        await Assert.That(async () => await releaseOnly.DisposeAsync()).Throws<InvalidOperationException>();
+        await Assert.That(async () => await resourceOnly.DisposeAsync()).Throws<InvalidOperationException>();
+        await Assert.That(async () => await both.DisposeAsync()).Throws<InvalidOperationException>();
+
+        await Assert.That(releasedAfterResourceFailure).IsTrue();
+        await Assert.That(releaseOnly.IsDisposed).IsTrue();
+        await Assert.That(resourceOnly.IsDisposed).IsTrue();
+        await Assert.That(both.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Exercises all start and stop overloads.</summary>
+    /// <param name="server">The server under test.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task ExerciseLifecycleOperationsAsync(MqttServer server)
+    {
+        _ = await server.Start().FirstAsync(OperationTimeout);
+        _ = await server.Stop().FirstAsync(OperationTimeout);
+        _ = await server.ObserveStart().FirstAsync(OperationTimeout);
+        _ = await server.Stop(new MqttServerStopOptions()).FirstAsync(OperationTimeout);
+        _ = await server.Start().FirstAsync(OperationTimeout);
+        _ = await server.Stop(static _ => { }).FirstAsync(OperationTimeout);
+        _ = await server.ObserveStart().FirstAsync(OperationTimeout);
+        _ = await server.ObserveStop().FirstAsync(OperationTimeout);
+        _ = await server.Start().FirstAsync(OperationTimeout);
+        _ = await server.ObserveStop(new MqttServerStopOptions()).FirstAsync(OperationTimeout);
+        _ = await server.ObserveStart().FirstAsync(OperationTimeout);
+        _ = await server.ObserveStop(static _ => { }).FirstAsync(OperationTimeout);
+    }
+
+    /// <summary>Exercises message injection and retained-message clearing.</summary>
+    /// <param name="server">The live server.</param>
+    /// <param name="message">The message to inject.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task ExerciseMessageAndRetainedOperationsAsync(
+        MqttServer server,
+        MqttApplicationMessage message)
+    {
+        var injected = new InjectedMqttApplicationMessage(message);
+        _ = await server.InjectApplicationMessageOperation(injected).FirstAsync(OperationTimeout);
+        _ = await server.ObserveInjectApplicationMessage(injected).FirstAsync(OperationTimeout);
+        _ = await server.DeleteRetainedMessages().FirstAsync(OperationTimeout);
+        _ = await server.ObserveUpdateRetainedMessage(message).FirstAsync(OperationTimeout);
+        _ = await server.ObserveDeleteRetainedMessages().FirstAsync(OperationTimeout);
+    }
+
+    /// <summary>Exercises all direct server client-disconnect overloads.</summary>
+    /// <param name="broker">The live broker.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task ExerciseServerDisconnectOperationsAsync(LiveMqttBroker broker)
+    {
+        var bridgeOptions = broker.BridgeClient.Options ?? throw new InvalidOperationException("Bridge options missing.");
+        var probeOptions = broker.ProbeClient.Options ?? throw new InvalidOperationException("Probe options missing.");
+        var disconnectOptions = new MqttServerClientDisconnectOptionsBuilder().Build();
+        _ = await broker.Server.DisconnectClient(broker.BridgeClientId, disconnectOptions)
+            .FirstAsync(OperationTimeout);
+        await WaitUntilAsync(() => !broker.BridgeClient.IsConnected);
+        await ConnectWhenReadyAsync(broker.BridgeClient, bridgeOptions);
+        _ = await broker.Server.DisconnectClient(broker.ProbeClientId, static _ => { })
+            .FirstAsync(OperationTimeout);
+        await WaitUntilAsync(() => !broker.ProbeClient.IsConnected);
+        await ConnectWhenReadyAsync(broker.ProbeClient, probeOptions);
+        _ = await broker.Server.ObserveDisconnectClient(broker.BridgeClientId, disconnectOptions)
+            .FirstAsync(OperationTimeout);
+        await WaitUntilAsync(() => !broker.BridgeClient.IsConnected);
+        await ConnectWhenReadyAsync(broker.BridgeClient, bridgeOptions);
+        _ = await broker.Server.ObserveDisconnectClient(broker.ProbeClientId, static _ => { })
+            .FirstAsync(OperationTimeout);
+        await WaitUntilAsync(() => !broker.ProbeClient.IsConnected);
+    }
+
+    /// <summary>Exercises a broker client status.</summary>
+    /// <param name="client">The client status.</param>
+    /// <param name="session">The session assigned to the client.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task ExerciseClientStatusAsync(MqttClientStatus client, MqttSessionStatus session)
+    {
+        var immediate = client.Properties();
+        var property = await client.Property(static value => value.Id).FirstAsync(OperationTimeout);
+        var observedProperty = await client.ObserveProperty(static value => value.ProtocolVersion)
+            .FirstAsync(OperationTimeout);
+        var snapshot = await client.PropertySnapshots().FirstAsync(OperationTimeout);
+        var observedSnapshot = await client.ObservePropertySnapshots().FirstAsync(OperationTimeout);
+        var sameClient = client.WithSession(session);
+        _ = await client.ResetStatisticsOperation().FirstAsync(OperationTimeout);
+        _ = await client.ObserveResetStatistics().FirstAsync(OperationTimeout);
+
+        await Assert.That(immediate.Id).IsEqualTo(client.Id);
+        await Assert.That(property).IsEqualTo(client.Id);
+        await Assert.That(observedProperty).IsEqualTo(client.ProtocolVersion);
+        await Assert.That(snapshot.Id).IsEqualTo(client.Id);
+        await Assert.That(observedSnapshot.Id).IsEqualTo(client.Id);
+        await Assert.That(sameClient).IsSameReferenceAs(client);
+    }
+
+    /// <summary>Exercises a broker session status.</summary>
+    /// <param name="session">The session status.</param>
+    /// <param name="topic">The message topic.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    private static async Task ExerciseSessionStatusAsync(MqttSessionStatus session, string topic)
+    {
+        var sameSession = session.WithSessionItem("one", SessionItemValue).WithoutSessionItem("missing");
+        var immediate = session.Properties();
+        var property = await session.Property(static value => value.Id).FirstAsync(OperationTimeout);
+        var observedProperty = await session.ObserveProperty(static value => value.PendingApplicationMessagesCount)
+            .FirstAsync(OperationTimeout);
+        var snapshot = await session.PropertySnapshots().FirstAsync(OperationTimeout);
+        var observedSnapshot = await session.ObservePropertySnapshots().FirstAsync(OperationTimeout);
+        var message = CreateMessage(topic, false);
+        var enqueued = await session.TryEnqueueApplicationMessage(message).FirstAsync(OperationTimeout);
+        var observedEnqueued = await session.ObserveTryEnqueueApplicationMessage(message).FirstAsync(OperationTimeout);
+        _ = await session.DeliverApplicationMessage(message).FirstAsync(OperationTimeout);
+        _ = await session.ObserveDeliverApplicationMessage(message).FirstAsync(OperationTimeout);
+        await Assert.That(async () =>
+                _ = await session.ClearApplicationMessagesQueue().FirstAsync(OperationTimeout))
+            .Throws<NotImplementedException>();
+        await Assert.That(async () =>
+                _ = await session.ObserveClearApplicationMessagesQueue().FirstAsync(OperationTimeout))
+            .Throws<InvalidOperationException>();
+        _ = session.ClearSessionItems().Properties();
+
+        await Assert.That(sameSession).IsSameReferenceAs(session);
+        await Assert.That(immediate.Id).IsEqualTo(session.Id);
+        await Assert.That(property).IsEqualTo(session.Id);
+        await Assert.That(observedProperty).IsGreaterThanOrEqualTo(0);
+        await Assert.That(snapshot.Id).IsEqualTo(session.Id);
+        await Assert.That(observedSnapshot.Id).IsEqualTo(session.Id);
+        await Assert.That(enqueued.InjectResult).IsNotNull();
+        await Assert.That(observedEnqueued.InjectResult).IsNotNull();
+    }
+
+    /// <summary>Finds a client status by identifier without allocating a LINQ iterator.</summary>
+    /// <param name="statuses">The client statuses.</param>
+    /// <param name="clientId">The client identifier.</param>
+    /// <returns>The matching status.</returns>
+    private static MqttClientStatus FindClientStatus(IEnumerable<MqttClientStatus> statuses, string clientId)
+    {
+        foreach (var status in statuses)
+        {
+            if (status.Id == clientId)
+            {
+                return status;
+            }
+        }
+
+        throw new InvalidOperationException($"Client status '{clientId}' was not found.");
+    }
+
+    /// <summary>Finds a session status by identifier without allocating a LINQ iterator.</summary>
+    /// <param name="statuses">The session statuses.</param>
+    /// <param name="clientId">The client identifier.</param>
+    /// <returns>The matching status.</returns>
+    private static MqttSessionStatus FindSessionStatus(IEnumerable<MqttSessionStatus> statuses, string clientId)
+    {
+        foreach (var status in statuses)
+        {
+            if (status.Id == clientId)
+            {
+                return status;
+            }
+        }
+
+        throw new InvalidOperationException($"Session status '{clientId}' was not found.");
+    }
+
+    /// <summary>Creates a server without network endpoints.</summary>
+    /// <returns>The configured server.</returns>
+    private static MqttServer CreateServer()
+    {
+        var factory = new MqttServerFactory();
+        var options = factory.CreateServerOptionsBuilder().WithoutDefaultEndpoint().Build();
+        return factory.CreateMqttServer(options);
+    }
+
+    /// <summary>Creates an application message.</summary>
+    /// <param name="topic">The message topic.</param>
+    /// <param name="retain">Whether the message is retained.</param>
+    /// <returns>The configured application message.</returns>
+    private static MqttApplicationMessage CreateMessage(string topic, bool retain) =>
+        new MqttApplicationMessageBuilder().WithTopic(topic).WithPayload("payload").WithRetainFlag(retain).Build();
+
+    /// <summary>Invokes the server factory notification boundary with a rejecting asynchronous observer.</summary>
+    /// <param name="server">The server owned by the rejected session.</param>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    private static async Task ExerciseServerNotifyObserverFailureAsync(MqttServer server)
+    {
+        var session = CreateServerSession(server, static () => ValueTask.CompletedTask);
+        var notify = typeof(ServerCreate).GetMethod(
+            "NotifyObserverAsync",
+            BindingFlags.Static | BindingFlags.NonPublic) ??
+            throw new InvalidOperationException("Server notification method was not found.");
+        var observer = new ControlledAsyncObserver<(MqttServer Server, MqttServerSession Disposable)>(
+            new InvalidOperationException("Reject server lease."));
+        var operation = notify.Invoke(null, [observer, session, CancellationToken.None]) ??
+            throw new InvalidOperationException("Server notification operation was not created.");
+        var asTask = operation.GetType().GetMethod("AsTask", BindingFlags.Instance | BindingFlags.Public) ??
+            throw new InvalidOperationException("Server notification task adapter was not found.");
+        var task = (Task)(asTask.Invoke(operation, null) ??
+            throw new InvalidOperationException("Server notification task was not created."));
+
+        await Assert.That(async () => await task).Throws<InvalidOperationException>();
+        await Assert.That(session.IsDisposed).IsTrue();
+    }
+
+    /// <summary>Creates a server session through its package-internal constructor.</summary>
+    /// <param name="server">The session server.</param>
+    /// <param name="release">The session release callback.</param>
+    /// <returns>The created server session.</returns>
+    private static MqttServerSession CreateServerSession(MqttServer server, Func<ValueTask> release)
+    {
+        var constructor = typeof(MqttServerSession).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(MqttServer), typeof(Func<ValueTask>)],
+            modifiers: null) ?? throw new InvalidOperationException("Server session constructor was not found.");
+        return (MqttServerSession)constructor.Invoke([server, release]);
+    }
+
+    /// <summary>Invokes a reflected method that returns a non-generic value task.</summary>
+    /// <param name="ownerType">The method owner type.</param>
+    /// <param name="owner">The method owner instance.</param>
+    /// <param name="methodName">The method name.</param>
+    /// <param name="bindingFlags">The reflection binding flags.</param>
+    /// <param name="argument">The optional Boolean argument.</param>
+    /// <returns>A task that represents the reflected operation.</returns>
+    private static async Task InvokeValueTaskAsync(
+        Type ownerType,
+        object owner,
+        string methodName,
+        BindingFlags bindingFlags,
+        bool? argument = null)
+    {
+        var method = ownerType.GetMethod(methodName, bindingFlags) ??
+            throw new InvalidOperationException($"Value-task method '{methodName}' was not found.");
+        object?[]? arguments = argument.HasValue ? [argument.Value] : null;
+        var operation = (ValueTask)(method.Invoke(owner, arguments) ??
+            throw new InvalidOperationException($"Value-task method '{methodName}' returned no operation."));
+        await operation;
+    }
+
+    /// <summary>Reconnects after MQTTnet's previous disconnect state transition has fully settled.</summary>
+    /// <param name="client">The client to reconnect.</param>
+    /// <param name="options">The connection options.</param>
+    /// <returns>A task that completes when the client reconnects.</returns>
+    private static async Task ConnectWhenReadyAsync(IMqttClient client, MqttClientOptions options)
+    {
+        using var cancellation = new CancellationTokenSource(OperationTimeout);
+        while (true)
+        {
+            try
+            {
+                _ = await client.ConnectAsync(options, cancellation.Token);
+                return;
+            }
+            catch (InvalidOperationException) when (!cancellation.IsCancellationRequested)
+            {
+                await Task.Yield();
+            }
+        }
+    }
+
+    /// <summary>Waits for a bounded broker lifecycle condition.</summary>
+    /// <param name="condition">The condition to observe.</param>
+    /// <returns>A task that completes when the condition becomes true.</returns>
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        using var cancellation = new CancellationTokenSource(OperationTimeout);
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
+        while (!condition())
+        {
+            _ = await timer.WaitForNextTickAsync(cancellation.Token);
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Client.Tests/ServerCoverageTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/ServerCoverageTests.cs
@@ -98,6 +98,7 @@ public class ServerCoverageTests
     {
         using var server = CreateServer();
 
+        SubscribeAndDispose(server.ApplicationMessageEnqueuedOrDropped());
         SubscribeAndDispose(server.ApplicationMessageNotConsumed());
         SubscribeAndDispose(server.ClientAcknowledgedPublishPacket());
         SubscribeAndDispose(server.ClientConnected());
@@ -112,6 +113,7 @@ public class ServerCoverageTests
         SubscribeAndDispose(server.InterceptingUnsubscription());
         SubscribeAndDispose(server.LoadingRetainedMessage());
         SubscribeAndDispose(server.PreparingSession());
+        SubscribeAndDispose(server.QueuedApplicationMessageOverwritten());
         SubscribeAndDispose(server.RetainedMessageChanged());
         SubscribeAndDispose(server.RetainedMessagesCleared());
         SubscribeAndDispose(server.SessionDeleted());
@@ -129,6 +131,7 @@ public class ServerCoverageTests
     {
         using var server = CreateServer();
 
+        await SubscribeAndDisposeAsync(server.ObserveApplicationMessageEnqueuedOrDropped());
         await SubscribeAndDisposeAsync(server.ObserveApplicationMessageNotConsumed());
         await SubscribeAndDisposeAsync(server.ObserveClientAcknowledgedPublishPacket());
         await SubscribeAndDisposeAsync(server.ObserveClientConnected());
@@ -143,6 +146,7 @@ public class ServerCoverageTests
         await SubscribeAndDisposeAsync(server.ObserveInterceptingUnsubscription());
         await SubscribeAndDisposeAsync(server.ObserveLoadingRetainedMessage());
         await SubscribeAndDisposeAsync(server.ObservePreparingSession());
+        await SubscribeAndDisposeAsync(server.ObserveQueuedApplicationMessageOverwritten());
         await SubscribeAndDisposeAsync(server.ObserveRetainedMessageChanged());
         await SubscribeAndDisposeAsync(server.ObserveRetainedMessagesCleared());
         await SubscribeAndDisposeAsync(server.ObserveSessionDeleted());

--- a/src/MQTTnet.Rx.Client.Tests/Wave2MqttdOptionsCoverageTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/Wave2MqttdOptionsCoverageTests.cs
@@ -156,7 +156,7 @@ public sealed class Wave2MqttdOptionsCoverageTests
         using var connected = client.Connected().Subscribe(static _ => { });
         using var connecting = client.Connecting().Subscribe(static _ => { });
         await using var connectingAsync = await SubscribeAsync(client.ObserveConnecting());
-        using var inspected = client.InspectPackage().Subscribe(static _ => { });
+        using var inspected = client.InspectPacket().Subscribe(static _ => { });
 
         // Assert
         await Assert.That(received).IsNotNull();

--- a/src/MQTTnet.Rx.Client.Tests/Wave2ServerCoverageTests.cs
+++ b/src/MQTTnet.Rx.Client.Tests/Wave2ServerCoverageTests.cs
@@ -31,6 +31,7 @@ public class Wave2ServerCoverageTests
     {
         using var server = CreateServer();
 
+        await SubscribeAndDisposeAsync(server.ObserveApplicationMessageEnqueuedOrDropped());
         await SubscribeAndDisposeAsync(server.ObserveApplicationMessageNotConsumed());
         await SubscribeAndDisposeAsync(server.ObserveClientAcknowledgedPublishPacket());
         await SubscribeAndDisposeAsync(server.ObserveClientConnected());
@@ -45,6 +46,7 @@ public class Wave2ServerCoverageTests
         await SubscribeAndDisposeAsync(server.ObserveInterceptingUnsubscription());
         await SubscribeAndDisposeAsync(server.ObserveLoadingRetainedMessage());
         await SubscribeAndDisposeAsync(server.ObservePreparingSession());
+        await SubscribeAndDisposeAsync(server.ObserveQueuedApplicationMessageOverwritten());
         await SubscribeAndDisposeAsync(server.ObserveRetainedMessageChanged());
         await SubscribeAndDisposeAsync(server.ObserveRetainedMessagesCleared());
         await SubscribeAndDisposeAsync(server.ObserveSessionDeleted());

--- a/src/MQTTnet.Rx.Client/Create.cs
+++ b/src/MQTTnet.Rx.Client/Create.cs
@@ -8,8 +8,6 @@ using MQTTnet.Rx.Client.Reactive.ResilientClient.Internal;
 using MQTTnet.Rx.Client.ResilientClient.Internal;
 #endif
 using ReactiveUI.Primitives.Async;
-using ReactiveUI.Primitives.Async.Disposables;
-using ReactiveUI.Primitives.Disposables;
 #if REACTIVE_SHIM
 using ReactiveUI.Primitives.Reactive.Signals;
 #else
@@ -29,18 +27,25 @@ namespace MQTTnet.Rx.Client;
 /// designed for use in multi-threaded environments.</remarks>
 public static class Create
 {
+    /// <summary>Stores the current MQTT client factory.</summary>
+    private static MqttClientFactory _mqttFactory = new();
+
     /// <summary>Gets the default factory instance for creating MQTT clients.</summary>
     /// <remarks>Use this property to obtain a shared instance of the MQTT client factory when creating new
     /// MQTT client connections. The returned factory is thread-safe and intended for reuse throughout the
     /// application.</remarks>
-    public static MqttClientFactory MqttFactory { get; private set; } = new();
+    public static MqttClientFactory MqttFactory => Volatile.Read(ref _mqttFactory);
 
     /// <summary>Sets the global MQTT client factory instance to use for creating MQTT clients.</summary>
     /// <remarks>Use this method to replace the default MQTT client factory with a custom implementation. This
     /// affects all future MQTT client creation operations that rely on the global factory instance.</remarks>
     /// <param name="mqttFactory">The MQTT client factory to be used for subsequent client creation. Cannot be
     /// null.</param>
-    public static void NewMqttFactory(MqttClientFactory mqttFactory) => MqttFactory = mqttFactory;
+    public static void NewMqttFactory(MqttClientFactory mqttFactory)
+    {
+        ArgumentNullException.ThrowIfNull(mqttFactory);
+        _ = Interlocked.Exchange(ref _mqttFactory, mqttFactory);
+    }
 
     /// <summary>Creates an observable sequence that provides a shared instance of an MQTT client.</summary>
     /// <remarks>The returned observable shares a single underlying MQTT client instance among all
@@ -51,24 +56,12 @@ public static class Create
     /// client is disposed when all subscriptions are disposed.</returns>
     public static IObservable<IMqttClient> MqttClient()
     {
-        var mqttClient = MqttFactory.CreateMqttClient();
-        var clientCount = new int[1];
+        var lifetime = new SharedClientLifetime<IMqttClient>(static () => MqttFactory.CreateMqttClient());
         return CreateObservable.RetryForever(
             Signal.Create<IMqttClient>(observer =>
             {
-                observer.OnNext(mqttClient);
-                _ = Interlocked.Increment(ref clientCount[0]);
-                return Scope.Create(
-                    (mqttClient, clientCount),
-                    static state =>
-                    {
-                        if (Interlocked.Decrement(ref state.clientCount[0]) != 0)
-                        {
-                            return;
-                        }
-
-                        state.mqttClient.Dispose();
-                    });
+                var lease = lifetime.Acquire();
+                return NotifyObserver(observer, lease);
             }));
     }
 
@@ -76,27 +69,13 @@ public static class Create
     /// <returns>An asynchronous observable sequence that emits a shared <see cref="IMqttClient"/> instance.</returns>
     public static IObservableAsync<IMqttClient> MqttClientSignal()
     {
-        var mqttClient = MqttFactory.CreateMqttClient();
-        var clientCount = new int[1];
+        var lifetime = new SharedClientLifetime<IMqttClient>(static () => MqttFactory.CreateMqttClient());
         return SignalAsync
             .Create<IMqttClient>(
                 async (observer, cancellationToken) =>
                 {
-                    await observer.OnNextAsync(mqttClient, cancellationToken).ConfigureAwait(false);
-                    _ = Interlocked.Increment(ref clientCount[0]);
-
-                    return DisposableAsync.Create(
-                        (mqttClient, clientCount),
-                        static state =>
-                        {
-                            if (Interlocked.Decrement(ref state.clientCount[0]) != 0)
-                            {
-                                return default;
-                            }
-
-                            state.mqttClient.Dispose();
-                            return default;
-                        });
+                    var lease = lifetime.Acquire();
+                    return await NotifyObserverAsync(observer, lease, cancellationToken).ConfigureAwait(false);
                 })
             .Retry();
     }
@@ -112,24 +91,13 @@ public static class Create
     /// disposed when all subscriptions are disposed.</returns>
     public static IObservable<IResilientMqttClient> ResilientMqttClient()
     {
-        var mqttClient = CreateResilientMqttClient(MqttFactory);
-        var clientCount = new int[1];
+        var lifetime = new SharedClientLifetime<IResilientMqttClient>(
+            static () => CreateResilientMqttClient(MqttFactory));
         return CreateObservable.RetryForever(
             Signal.Create<IResilientMqttClient>(observer =>
             {
-                observer.OnNext(mqttClient);
-                _ = Interlocked.Increment(ref clientCount[0]);
-                return Scope.Create(
-                    (mqttClient, clientCount),
-                    static state =>
-                    {
-                        if (Interlocked.Decrement(ref state.clientCount[0]) != 0)
-                        {
-                            return;
-                        }
-
-                        state.mqttClient.Dispose();
-                    });
+                var lease = lifetime.Acquire();
+                return NotifyObserver(observer, lease);
             }));
     }
 
@@ -138,27 +106,14 @@ public static class Create
     /// instance.</returns>
     public static IObservableAsync<IResilientMqttClient> ResilientMqttClientSignal()
     {
-        var mqttClient = CreateResilientMqttClient(MqttFactory);
-        var clientCount = new int[1];
+        var lifetime = new SharedClientLifetime<IResilientMqttClient>(
+            static () => CreateResilientMqttClient(MqttFactory));
         return SignalAsync
             .Create<IResilientMqttClient>(
                 async (observer, cancellationToken) =>
                 {
-                    await observer.OnNextAsync(mqttClient, cancellationToken).ConfigureAwait(false);
-                    _ = Interlocked.Increment(ref clientCount[0]);
-
-                    return DisposableAsync.Create(
-                        (mqttClient, clientCount),
-                        static state =>
-                        {
-                            if (Interlocked.Decrement(ref state.clientCount[0]) != 0)
-                            {
-                                return default;
-                            }
-
-                            state.mqttClient.Dispose();
-                            return default;
-                        });
+                    var lease = lifetime.Acquire();
+                    return await NotifyObserverAsync(observer, lease, cancellationToken).ConfigureAwait(false);
                 })
             .Retry();
     }
@@ -218,5 +173,128 @@ public static class Create
     {
         ArgumentNullException.ThrowIfNull(factory);
         return new(factory.CreateMqttClient(), factory.DefaultLogger);
+    }
+
+    /// <summary>Notifies a synchronous observer and releases a rejected client lease.</summary>
+    /// <typeparam name="T">The client type.</typeparam>
+    /// <param name="observer">The receiving observer.</param>
+    /// <param name="lease">The acquired client lease.</param>
+    /// <returns>The accepted lease.</returns>
+    private static SharedClientLifetime<T>.ClientLease NotifyObserver<T>(
+        IObserver<T> observer,
+        SharedClientLifetime<T>.ClientLease lease)
+        where T : class, IDisposable
+    {
+        try
+        {
+            observer.OnNext(lease.Client);
+            return lease;
+        }
+        catch
+        {
+            lease.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Notifies an asynchronous observer and releases a rejected client lease.</summary>
+    /// <typeparam name="T">The client type.</typeparam>
+    /// <param name="observer">The receiving observer.</param>
+    /// <param name="lease">The acquired client lease.</param>
+    /// <param name="cancellationToken">Cancels notification.</param>
+    /// <returns>The accepted lease.</returns>
+    private static async ValueTask<SharedClientLifetime<T>.ClientLease> NotifyObserverAsync<T>(
+        IObserverAsync<T> observer,
+        SharedClientLifetime<T>.ClientLease lease,
+        CancellationToken cancellationToken)
+        where T : class, IDisposable
+    {
+        try
+        {
+            await observer.OnNextAsync(lease.Client, cancellationToken).ConfigureAwait(false);
+            return lease;
+        }
+        catch
+        {
+            lease.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>Owns one shared client per active subscription wave.</summary>
+    /// <typeparam name="T">The disposable client type.</typeparam>
+    /// <param name="factory">Creates a client for a new subscription wave.</param>
+    internal sealed class SharedClientLifetime<T>(Func<T> factory)
+        where T : class, IDisposable
+    {
+        /// <summary>Serializes acquisition and release.</summary>
+#if NET9_0_OR_GREATER
+        private readonly Lock _gate = new();
+#else
+        private readonly object _gate = new();
+#endif
+
+        /// <summary>Stores the active shared client.</summary>
+        private T? _client;
+
+        /// <summary>Tracks active leases.</summary>
+        private int _leaseCount;
+
+        /// <summary>Acquires a client lease.</summary>
+        /// <returns>A lease over the current shared client.</returns>
+        internal ClientLease Acquire()
+        {
+            lock (_gate)
+            {
+                _client ??= factory();
+                _leaseCount++;
+                return new(this, _client);
+            }
+        }
+
+        /// <summary>Releases one lease and disposes the client after the final release.</summary>
+        private void Release()
+        {
+            T? client = null;
+            lock (_gate)
+            {
+                _leaseCount--;
+                if (_leaseCount == 0)
+                {
+                    client = _client;
+                    _client = null;
+                }
+            }
+
+            client?.Dispose();
+        }
+
+        /// <summary>Owns one subscription's share of the client lifetime.</summary>
+        /// <param name="owner">The shared lifetime owner.</param>
+        /// <param name="client">The leased client.</param>
+        internal sealed class ClientLease(SharedClientLifetime<T> owner, T client) : IDisposable, IAsyncDisposable
+        {
+            /// <summary>Tracks whether this lease was released.</summary>
+            private int _disposed;
+
+            /// <summary>Gets the leased client.</summary>
+            internal T Client { get; } = client;
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                {
+                    owner.Release();
+                }
+            }
+
+            /// <inheritdoc/>
+            public ValueTask DisposeAsync()
+            {
+                Dispose();
+                return ValueTask.CompletedTask;
+            }
+        }
     }
 }

--- a/src/MQTTnet.Rx.Client/MqttClientAsyncAutoReconnectExtensions.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientAsyncAutoReconnectExtensions.cs
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Async;
+using ReactiveUI.Primitives.Async.Disposables;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Provides automatic reconnection for asynchronous MQTT client sequences.</summary>
+public static class MqttClientAsyncAutoReconnectExtensions
+{
+    /// <summary>The default delay before reconnecting.</summary>
+    private static readonly TimeSpan DefaultReconnectDelay = TimeSpan.FromSeconds(5);
+
+    /// <summary>Provides connection recovery for asynchronous MQTT client sequences.</summary>
+    /// <param name="clients">The asynchronous MQTT client sequence.</param>
+    extension(IObservableAsync<IMqttClient> clients)
+    {
+        /// <summary>Monitors disconnections and reconnects without an attempt limit.</summary>
+        /// <returns>The auto-reconnecting client sequence.</returns>
+        public IObservableAsync<IMqttClient> WithAutoReconnect() => clients.WithAutoReconnect(null, 0);
+
+        /// <summary>Monitors disconnections and reconnects without an attempt limit.</summary>
+        /// <param name="reconnectDelay">The delay before each reconnect attempt.</param>
+        /// <returns>The auto-reconnecting client sequence.</returns>
+        public IObservableAsync<IMqttClient> WithAutoReconnect(TimeSpan? reconnectDelay) =>
+            clients.WithAutoReconnect(reconnectDelay, 0);
+
+        /// <summary>Monitors disconnections and reconnects using the supplied retry policy.</summary>
+        /// <param name="reconnectDelay">The delay before each reconnect attempt.</param>
+        /// <param name="maxReconnectAttempts">The maximum attempts; zero means unlimited.</param>
+        /// <returns>The auto-reconnecting client sequence.</returns>
+        public IObservableAsync<IMqttClient> WithAutoReconnect(
+            TimeSpan? reconnectDelay,
+            int maxReconnectAttempts)
+        {
+            var delay = reconnectDelay ?? DefaultReconnectDelay;
+            return SignalAsync.Create<IMqttClient>(async (observer, cancellationToken) =>
+            {
+                var disposables = new MultipleDisposableAsync();
+                await disposables.AddAsync(
+                    await clients.SubscribeAsync(
+                        async (client, token) =>
+                        {
+                            if (client.IsConnected)
+                            {
+                                await observer.OnNextAsync(client, token).ConfigureAwait(false);
+                            }
+
+                            var reconnecting = 0;
+                            await disposables.AddAsync(
+                                await client.ObserveDisconnected().SubscribeAsync(
+                                    async (eventArgs, handlerToken) =>
+                                    {
+                                        GC.KeepAlive(eventArgs);
+                                        GC.KeepAlive(handlerToken);
+                                        if (Interlocked.Exchange(ref reconnecting, 1) != 0)
+                                        {
+                                            return;
+                                        }
+
+                                        try
+                                        {
+                                            await ReconnectAsync(
+                                                client,
+                                                delay,
+                                                maxReconnectAttempts,
+                                                observer,
+                                                cancellationToken).ConfigureAwait(false);
+                                        }
+                                        finally
+                                        {
+                                            _ = Interlocked.Exchange(ref reconnecting, 0);
+                                        }
+                                    },
+                                    token).ConfigureAwait(false)).ConfigureAwait(false);
+                        },
+                        cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+                return disposables;
+            });
+        }
+    }
+
+    /// <summary>Reconnects until successful, cancelled, or the attempt limit is reached.</summary>
+    /// <param name="client">The disconnected client.</param>
+    /// <param name="delay">The retry delay.</param>
+    /// <param name="maxReconnectAttempts">The maximum attempts; zero means unlimited.</param>
+    /// <param name="observer">The downstream observer.</param>
+    /// <param name="cancellationToken">Cancels reconnection.</param>
+    /// <returns>A task that represents reconnection.</returns>
+    private static async Task ReconnectAsync(
+        IMqttClient client,
+        TimeSpan delay,
+        int maxReconnectAttempts,
+        IObserverAsync<IMqttClient> observer,
+        CancellationToken cancellationToken)
+    {
+        var attempts = 0;
+        while (true)
+        {
+            try
+            {
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                attempts++;
+                await client.ReconnectAsync(cancellationToken).ConfigureAwait(false);
+                await observer.OnNextAsync(client, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception) when (maxReconnectAttempts == 0 || attempts < maxReconnectAttempts)
+            {
+            }
+            catch (Exception exception)
+            {
+                await observer.OnErrorResumeAsync(exception, cancellationToken).ConfigureAwait(false);
+                return;
+            }
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Client/MqttClientExtensions.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientExtensions.cs
@@ -76,16 +76,17 @@ public static class MqttClientExtensions
 
         /// <summary>Observes MQTT packet inspection events.</summary>
         /// <returns>An observable sequence of MQTT packet inspection events.</returns>
-        public IObservable<InspectMqttPacketEventArgs> InspectPackage() =>
+        public IObservable<InspectMqttPacketEventArgs> InspectPacket() =>
             CreateObservable.FromAsyncEvent<InspectMqttPacketEventArgs>(
                 handler => client.InspectPacketAsync += handler,
                 handler => client.InspectPacketAsync -= handler);
 
         /// <summary>Observes MQTT packet inspection events asynchronously.</summary>
         /// <returns>An asynchronous observable sequence of MQTT packet inspection events.</returns>
-        public IObservableAsync<InspectMqttPacketEventArgs> ObserveInspectPackage() =>
+        public IObservableAsync<InspectMqttPacketEventArgs> ObserveInspectPacket() =>
             CreateObservable.FromAsyncEventSignal<InspectMqttPacketEventArgs>(
                 handler => client.InspectPacketAsync += handler,
                 handler => client.InspectPacketAsync -= handler);
+
     }
 }

--- a/src/MQTTnet.Rx.Client/MqttClientOperationExtensions.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientOperationExtensions.cs
@@ -1,0 +1,530 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using MQTTnet.Protocol;
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Reactive.Signals;
+#else
+using ReactiveUI.Primitives.Signals;
+#endif
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Provides paired cold reactive wrappers for every MQTT client operation.</summary>
+public static class MqttClientOperationExtensions
+{
+    /// <summary>Provides direct reactive MQTT client operations.</summary>
+    /// <param name="client">The MQTT client.</param>
+    extension(IMqttClient client)
+    {
+        /// <summary>Connects using prebuilt options when subscribed.</summary>
+        /// <param name="options">The connection options.</param>
+        /// <returns>A cold connection operation.</returns>
+        public IObservable<MqttClientConnectResult> Connect(MqttClientOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.ConnectAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Connects using fluent option configuration when subscribed.</summary>
+        /// <param name="configure">Configures the connection options.</param>
+        /// <returns>A cold connection operation.</returns>
+        public IObservable<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientOptionsBuilder();
+            configure(builder);
+            return client.Connect(builder.Build());
+        }
+
+        /// <summary>Connects using prebuilt options through an asynchronous observable.</summary>
+        /// <param name="options">The connection options.</param>
+        /// <returns>A cold asynchronous connection operation.</returns>
+        public IObservableAsync<MqttClientConnectResult> ObserveConnect(MqttClientOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.ConnectAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Connects asynchronously using fluent option configuration.</summary>
+        /// <param name="configure">Configures the connection options.</param>
+        /// <returns>A cold asynchronous connection operation.</returns>
+        public IObservableAsync<MqttClientConnectResult> ObserveConnect(Action<MqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientOptionsBuilder();
+            configure(builder);
+            return client.ObserveConnect(builder.Build());
+        }
+
+        /// <summary>Disconnects using prebuilt options when subscribed.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxUnit> Disconnect(MqttClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.DisconnectAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Disconnects using fluent option configuration when subscribed.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientDisconnectOptionsBuilder();
+            configure(builder);
+            return client.Disconnect(builder.Build());
+        }
+
+        /// <summary>Disconnects using prebuilt options through an asynchronous observable.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxUnit> ObserveDisconnect(MqttClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.DisconnectAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Disconnects asynchronously using fluent option configuration.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxUnit> ObserveDisconnect(Action<MqttClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientDisconnectOptionsBuilder();
+            configure(builder);
+            return client.ObserveDisconnect(builder.Build());
+        }
+
+        /// <summary>Sends a ping when subscribed.</summary>
+        /// <returns>A cold ping operation.</returns>
+        public IObservable<RxUnit> Ping() => FromTask(client.PingAsync);
+
+        /// <summary>Sends a ping through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous ping operation.</returns>
+        public IObservableAsync<RxUnit> ObservePing() => FromTaskSignal(client.PingAsync);
+
+        /// <summary>Publishes a prebuilt application message when subscribed.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold publish operation.</returns>
+        public IObservable<MqttClientPublishResult> Publish(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.PublishAsync(message, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a fluently configured application message when subscribed.</summary>
+        /// <param name="configure">Configures the application message.</param>
+        /// <returns>A cold publish operation.</returns>
+        public IObservable<MqttClientPublishResult> Publish(Action<MqttApplicationMessageBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttApplicationMessageBuilder();
+            configure(builder);
+            return client.Publish(builder.Build());
+        }
+
+        /// <summary>Publishes a prebuilt application message through an asynchronous observable.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold asynchronous publish operation.</returns>
+        public IObservableAsync<MqttClientPublishResult> ObservePublish(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.PublishAsync(message, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a fluently configured application message through an asynchronous observable.</summary>
+        /// <param name="configure">Configures the application message.</param>
+        /// <returns>A cold asynchronous publish operation.</returns>
+        public IObservableAsync<MqttClientPublishResult> ObservePublish(
+            Action<MqttApplicationMessageBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttApplicationMessageBuilder();
+            configure(builder);
+            return client.ObservePublish(builder.Build());
+        }
+
+        /// <summary>Publishes a binary payload when subscribed.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold publish operation.</returns>
+        public IObservable<MqttClientPublishResult> PublishBinary(
+            string topic,
+            IEnumerable<byte>? payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.PublishBinaryAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a binary payload through an asynchronous observable.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold asynchronous publish operation.</returns>
+        public IObservableAsync<MqttClientPublishResult> ObservePublishBinary(
+            string topic,
+            IEnumerable<byte>? payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.PublishBinaryAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a sequence payload when subscribed.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload sequence.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold publish operation.</returns>
+        public IObservable<MqttClientPublishResult> PublishSequence(
+            string topic,
+            ReadOnlySequence<byte> payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.PublishSequenceAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a sequence payload through an asynchronous observable.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload sequence.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold asynchronous publish operation.</returns>
+        public IObservableAsync<MqttClientPublishResult> ObservePublishSequence(
+            string topic,
+            ReadOnlySequence<byte> payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.PublishSequenceAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a UTF-8 string payload when subscribed.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold publish operation.</returns>
+        public IObservable<MqttClientPublishResult> PublishString(
+            string topic,
+            string? payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.PublishStringAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Publishes a UTF-8 string payload through an asynchronous observable.</summary>
+        /// <param name="topic">The topic.</param>
+        /// <param name="payload">The payload.</param>
+        /// <param name="qualityOfServiceLevel">The quality-of-service level.</param>
+        /// <param name="retain">Whether the message is retained.</param>
+        /// <returns>A cold asynchronous publish operation.</returns>
+        public IObservableAsync<MqttClientPublishResult> ObservePublishString(
+            string topic,
+            string? payload,
+            MqttQualityOfServiceLevel qualityOfServiceLevel,
+            bool retain)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.PublishStringAsync(
+                    topic,
+                    payload,
+                    qualityOfServiceLevel,
+                    retain,
+                    cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Reconnects using the previous options when subscribed.</summary>
+        /// <returns>A cold reconnect operation.</returns>
+        public IObservable<RxUnit> Reconnect() => FromTask(client.ReconnectAsync);
+
+        /// <summary>Reconnects using the previous options through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous reconnect operation.</returns>
+        public IObservableAsync<RxUnit> ObserveReconnect() => FromTaskSignal(client.ReconnectAsync);
+
+        /// <summary>Sends enhanced-authentication exchange data when subscribed.</summary>
+        /// <param name="data">The authentication exchange data.</param>
+        /// <returns>A cold authentication operation.</returns>
+        public IObservable<RxUnit> SendEnhancedAuthenticationExchangeData(
+            MqttEnhancedAuthenticationExchangeData data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.SendEnhancedAuthenticationExchangeDataAsync(data, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Sends enhanced-authentication exchange data through an asynchronous observable.</summary>
+        /// <param name="data">The authentication exchange data.</param>
+        /// <returns>A cold asynchronous authentication operation.</returns>
+        public IObservableAsync<RxUnit> ObserveSendEnhancedAuthenticationExchangeData(
+            MqttEnhancedAuthenticationExchangeData data)
+        {
+            ArgumentNullException.ThrowIfNull(data);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.SendEnhancedAuthenticationExchangeDataAsync(data, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Subscribes using prebuilt options when subscribed.</summary>
+        /// <param name="options">The subscribe options.</param>
+        /// <returns>A cold subscribe operation.</returns>
+        public IObservable<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.SubscribeAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Subscribes using fluent option configuration when subscribed.</summary>
+        /// <param name="configure">Configures the subscribe options.</param>
+        /// <returns>A cold subscribe operation.</returns>
+        public IObservable<MqttClientSubscribeResult> Subscribe(Action<MqttClientSubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientSubscribeOptionsBuilder();
+            configure(builder);
+            return client.Subscribe(builder.Build());
+        }
+
+        /// <summary>Subscribes using prebuilt options through an asynchronous observable.</summary>
+        /// <param name="options">The subscribe options.</param>
+        /// <returns>A cold asynchronous subscribe operation.</returns>
+        public IObservableAsync<MqttClientSubscribeResult> ObserveSubscribe(MqttClientSubscribeOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.SubscribeAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Subscribes asynchronously using fluent option configuration.</summary>
+        /// <param name="configure">Configures the subscribe options.</param>
+        /// <returns>A cold asynchronous subscribe operation.</returns>
+        public IObservableAsync<MqttClientSubscribeResult> ObserveSubscribe(
+            Action<MqttClientSubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientSubscribeOptionsBuilder();
+            configure(builder);
+            return client.ObserveSubscribe(builder.Build());
+        }
+
+        /// <summary>Attempts to disconnect without propagating transport errors.</summary>
+        /// <returns>A cold disconnect-attempt operation.</returns>
+        public IObservable<bool> TryDisconnect() =>
+            client.TryDisconnect(MqttClientDisconnectOptionsReason.NormalDisconnection, null);
+
+        /// <summary>Attempts to disconnect without propagating transport errors.</summary>
+        /// <param name="reason">The disconnect reason.</param>
+        /// <param name="reasonString">The optional reason text.</param>
+        /// <returns>A cold disconnect-attempt operation.</returns>
+        public IObservable<bool> TryDisconnect(
+            MqttClientDisconnectOptionsReason reason,
+            string? reasonString) => FromTask(_ => client.TryDisconnectAsync(reason, reasonString));
+
+        /// <summary>Attempts to disconnect asynchronously without propagating transport errors.</summary>
+        /// <returns>A cold asynchronous disconnect-attempt operation.</returns>
+        public IObservableAsync<bool> ObserveTryDisconnect() =>
+            client.ObserveTryDisconnect(MqttClientDisconnectOptionsReason.NormalDisconnection, null);
+
+        /// <summary>Attempts to disconnect asynchronously without propagating transport errors.</summary>
+        /// <param name="reason">The disconnect reason.</param>
+        /// <param name="reasonString">The optional reason text.</param>
+        /// <returns>A cold asynchronous disconnect-attempt operation.</returns>
+        public IObservableAsync<bool> ObserveTryDisconnect(
+            MqttClientDisconnectOptionsReason reason,
+            string? reasonString) => FromTaskSignal(_ => client.TryDisconnectAsync(reason, reasonString));
+
+        /// <summary>Attempts to ping without propagating transport errors.</summary>
+        /// <returns>A cold ping-attempt operation.</returns>
+        public IObservable<bool> TryPing() => FromTask(client.TryPingAsync);
+
+        /// <summary>Attempts to ping asynchronously without propagating transport errors.</summary>
+        /// <returns>A cold asynchronous ping-attempt operation.</returns>
+        public IObservableAsync<bool> ObserveTryPing() => FromTaskSignal(client.TryPingAsync);
+
+        /// <summary>Unsubscribes using prebuilt options when subscribed.</summary>
+        /// <param name="options">The unsubscribe options.</param>
+        /// <returns>A cold unsubscribe operation.</returns>
+        public IObservable<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTask(cancellationToken =>
+            {
+                var operation = client.UnsubscribeAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Unsubscribes using fluent option configuration when subscribed.</summary>
+        /// <param name="configure">Configures the unsubscribe options.</param>
+        /// <returns>A cold unsubscribe operation.</returns>
+        public IObservable<MqttClientUnsubscribeResult> Unsubscribe(
+            Action<MqttClientUnsubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientUnsubscribeOptionsBuilder();
+            configure(builder);
+            return client.Unsubscribe(builder.Build());
+        }
+
+        /// <summary>Unsubscribes using prebuilt options through an asynchronous observable.</summary>
+        /// <param name="options">The unsubscribe options.</param>
+        /// <returns>A cold asynchronous unsubscribe operation.</returns>
+        public IObservableAsync<MqttClientUnsubscribeResult> ObserveUnsubscribe(
+            MqttClientUnsubscribeOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.UnsubscribeAsync(options, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Unsubscribes asynchronously using fluent option configuration.</summary>
+        /// <param name="configure">Configures the unsubscribe options.</param>
+        /// <returns>A cold asynchronous unsubscribe operation.</returns>
+        public IObservableAsync<MqttClientUnsubscribeResult> ObserveUnsubscribe(
+            Action<MqttClientUnsubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientUnsubscribeOptionsBuilder();
+            configure(builder);
+            return client.ObserveUnsubscribe(builder.Build());
+        }
+    }
+
+    /// <summary>Wraps a task result as a cold observable operation.</summary>
+    /// <typeparam name="T">The operation result type.</typeparam>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold observable operation.</returns>
+    private static IObservable<T> FromTask<T>(Func<CancellationToken, Task<T>> operation) =>
+        Signal.FromAsync(operation);
+
+    /// <summary>Wraps a task as a cold observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold observable operation.</returns>
+    private static IObservable<RxUnit> FromTask(Func<CancellationToken, Task> operation) =>
+        Signal.FromAsync(async cancellationToken =>
+        {
+            await operation(cancellationToken).ConfigureAwait(false);
+            return RxUnit.Default;
+        });
+
+    /// <summary>Wraps a task result as a cold asynchronous observable operation.</summary>
+    /// <typeparam name="T">The operation result type.</typeparam>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold asynchronous observable operation.</returns>
+    private static IObservableAsync<T> FromTaskSignal<T>(Func<CancellationToken, Task<T>> operation) =>
+        CreateObservable.FromAsyncTask(operation);
+
+    /// <summary>Wraps a task as a cold asynchronous observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold asynchronous observable operation.</returns>
+    private static IObservableAsync<RxUnit> FromTaskSignal(Func<CancellationToken, Task> operation) =>
+        CreateObservable.FromAsyncTask(operation);
+}

--- a/src/MQTTnet.Rx.Client/MqttClientProperties.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientProperties.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of every public MQTT client property.</summary>
+/// <param name="IsConnected">Whether the client is connected.</param>
+/// <param name="Options">The current client options, when available.</param>
+public sealed record MqttClientProperties(bool IsConnected, MqttClientOptions? Options);

--- a/src/MQTTnet.Rx.Client/MqttClientPropertyExtensions.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientPropertyExtensions.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Reactive.Signals;
+#else
+using ReactiveUI.Primitives.Signals;
+#endif
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Provides cold reactive projections for every public MQTT client property.</summary>
+public static class MqttClientPropertyExtensions
+{
+    /// <summary>Provides MQTT client property projections.</summary>
+    /// <param name="client">The MQTT client.</param>
+    extension(IMqttClient client)
+    {
+        /// <summary>Captures every public client property immediately.</summary>
+        /// <returns>The current client-property snapshot.</returns>
+        public MqttClientProperties Properties() => new(client.IsConnected, client.Options);
+
+        /// <summary>Reads an arbitrary client property once per subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<T> Property<T>(Func<IMqttClient, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return Signal.FromAsync(_ => Task.FromResult(selector(client)));
+        }
+
+        /// <summary>Reads an arbitrary client property once per asynchronous subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<T> ObserveProperty<T>(Func<IMqttClient, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return SignalAsync.FromAsync(_ => new ValueTask<T>(selector(client)));
+        }
+
+        /// <summary>Captures every public client property once per subscription.</summary>
+        /// <returns>A cold client-property snapshot.</returns>
+        public IObservable<MqttClientProperties> PropertySnapshots() =>
+            client.Property(static value => value.Properties());
+
+        /// <summary>Captures every public client property once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous client-property snapshot.</returns>
+        public IObservableAsync<MqttClientProperties> ObservePropertySnapshots() =>
+            client.ObserveProperty(static value => value.Properties());
+
+        /// <summary>Reads the connected state once per subscription.</summary>
+        /// <returns>A cold connected-state snapshot.</returns>
+        public IObservable<bool> IsConnectedValue() =>
+            client.Property(static value => value.IsConnected);
+
+        /// <summary>Reads the connected state once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous connected-state snapshot.</returns>
+        public IObservableAsync<bool> ObserveIsConnected() =>
+            client.ObserveProperty(static value => value.IsConnected);
+
+        /// <summary>Reads the current options once per subscription.</summary>
+        /// <returns>A cold options snapshot.</returns>
+        public IObservable<MqttClientOptions?> OptionsSnapshot() =>
+            client.Property(static value => (MqttClientOptions?)value.Options);
+
+        /// <summary>Reads the current options once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous options snapshot.</returns>
+        public IObservableAsync<MqttClientOptions?> ObserveOptionsSnapshot() =>
+            client.ObserveProperty(static value => (MqttClientOptions?)value.Options);
+    }
+}

--- a/src/MQTTnet.Rx.Client/MqttClientSequenceOperationExtensions.cs
+++ b/src/MQTTnet.Rx.Client/MqttClientSequenceOperationExtensions.cs
@@ -1,0 +1,190 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Async;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Adds full-options operation overloads to reactive MQTT client sequences.</summary>
+public static class MqttClientSequenceOperationExtensions
+{
+    /// <summary>Provides full-options operations for synchronous client sequences.</summary>
+    /// <param name="clients">The MQTT client sequence.</param>
+    extension(IObservable<IMqttClient> clients)
+    {
+        /// <summary>Connects each client with prebuilt options.</summary>
+        /// <param name="options">The connection options.</param>
+        /// <returns>The connection-result sequence.</returns>
+        public IObservable<MqttClientConnectResult> Connect(MqttClientOptions options) =>
+            clients.SelectMany(client => client.Connect(options));
+
+        /// <summary>Connects each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the connection options.</param>
+        /// <returns>The connection-result sequence.</returns>
+        public IObservable<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientOptionsBuilder();
+            configure(builder);
+            return clients.Connect(builder.Build());
+        }
+
+        /// <summary>Disconnects each client with prebuilt options.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>The disconnect-operation sequence.</returns>
+        public IObservable<RxUnit> Disconnect(MqttClientDisconnectOptions options) =>
+            clients.SelectMany(client => client.Disconnect(options));
+
+        /// <summary>Disconnects each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>The disconnect-operation sequence.</returns>
+        public IObservable<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientDisconnectOptionsBuilder();
+            configure(builder);
+            return clients.Disconnect(builder.Build());
+        }
+
+        /// <summary>Publishes a prebuilt message from each client.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>The publish-result sequence.</returns>
+        public IObservable<MqttClientPublishResult> Publish(MqttApplicationMessage message) =>
+            clients.SelectMany(client => client.Publish(message));
+
+        /// <summary>Sends enhanced-authentication exchange data from each client.</summary>
+        /// <param name="data">The authentication exchange data.</param>
+        /// <returns>The authentication-operation sequence.</returns>
+        public IObservable<RxUnit> SendEnhancedAuthenticationExchangeData(
+            MqttEnhancedAuthenticationExchangeData data) =>
+            clients.SelectMany(client => client.SendEnhancedAuthenticationExchangeData(data));
+
+        /// <summary>Subscribes each client with prebuilt options.</summary>
+        /// <param name="options">The subscribe options.</param>
+        /// <returns>The subscribe-result sequence.</returns>
+        public IObservable<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options) =>
+            clients.SelectMany(client => client.Subscribe(options));
+
+        /// <summary>Subscribes each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the subscribe options.</param>
+        /// <returns>The subscribe-result sequence.</returns>
+        public IObservable<MqttClientSubscribeResult> Subscribe(Action<MqttClientSubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientSubscribeOptionsBuilder();
+            configure(builder);
+            return clients.Subscribe(builder.Build());
+        }
+
+        /// <summary>Unsubscribes each client with prebuilt options.</summary>
+        /// <param name="options">The unsubscribe options.</param>
+        /// <returns>The unsubscribe-result sequence.</returns>
+        public IObservable<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options) =>
+            clients.SelectMany(client => client.Unsubscribe(options));
+
+        /// <summary>Unsubscribes each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the unsubscribe options.</param>
+        /// <returns>The unsubscribe-result sequence.</returns>
+        public IObservable<MqttClientUnsubscribeResult> Unsubscribe(
+            Action<MqttClientUnsubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientUnsubscribeOptionsBuilder();
+            configure(builder);
+            return clients.Unsubscribe(builder.Build());
+        }
+    }
+
+    /// <summary>Provides full-options operations for asynchronous client sequences.</summary>
+    /// <param name="clients">The asynchronous MQTT client sequence.</param>
+    extension(IObservableAsync<IMqttClient> clients)
+    {
+        /// <summary>Connects each client with prebuilt options.</summary>
+        /// <param name="options">The connection options.</param>
+        /// <returns>The asynchronous connection-result sequence.</returns>
+        public IObservableAsync<MqttClientConnectResult> Connect(MqttClientOptions options) =>
+            clients.SelectMany(client => client.ObserveConnect(options));
+
+        /// <summary>Connects each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the connection options.</param>
+        /// <returns>The asynchronous connection-result sequence.</returns>
+        public IObservableAsync<MqttClientConnectResult> Connect(Action<MqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientOptionsBuilder();
+            configure(builder);
+            return clients.Connect(builder.Build());
+        }
+
+        /// <summary>Disconnects each client with prebuilt options.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>The asynchronous disconnect-operation sequence.</returns>
+        public IObservableAsync<RxUnit> Disconnect(MqttClientDisconnectOptions options) =>
+            clients.SelectMany(client => client.ObserveDisconnect(options));
+
+        /// <summary>Disconnects each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>The asynchronous disconnect-operation sequence.</returns>
+        public IObservableAsync<RxUnit> Disconnect(Action<MqttClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientDisconnectOptionsBuilder();
+            configure(builder);
+            return clients.Disconnect(builder.Build());
+        }
+
+        /// <summary>Publishes a prebuilt message from each client.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>The asynchronous publish-result sequence.</returns>
+        public IObservableAsync<MqttClientPublishResult> Publish(MqttApplicationMessage message) =>
+            clients.SelectMany(client => client.ObservePublish(message));
+
+        /// <summary>Sends enhanced-authentication exchange data from each client.</summary>
+        /// <param name="data">The authentication exchange data.</param>
+        /// <returns>The asynchronous authentication-operation sequence.</returns>
+        public IObservableAsync<RxUnit> SendEnhancedAuthenticationExchangeData(
+            MqttEnhancedAuthenticationExchangeData data) =>
+            clients.SelectMany(client => client.ObserveSendEnhancedAuthenticationExchangeData(data));
+
+        /// <summary>Subscribes each client with prebuilt options.</summary>
+        /// <param name="options">The subscribe options.</param>
+        /// <returns>The asynchronous subscribe-result sequence.</returns>
+        public IObservableAsync<MqttClientSubscribeResult> Subscribe(MqttClientSubscribeOptions options) =>
+            clients.SelectMany(client => client.ObserveSubscribe(options));
+
+        /// <summary>Subscribes each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the subscribe options.</param>
+        /// <returns>The asynchronous subscribe-result sequence.</returns>
+        public IObservableAsync<MqttClientSubscribeResult> Subscribe(
+            Action<MqttClientSubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientSubscribeOptionsBuilder();
+            configure(builder);
+            return clients.Subscribe(builder.Build());
+        }
+
+        /// <summary>Unsubscribes each client with prebuilt options.</summary>
+        /// <param name="options">The unsubscribe options.</param>
+        /// <returns>The asynchronous unsubscribe-result sequence.</returns>
+        public IObservableAsync<MqttClientUnsubscribeResult> Unsubscribe(MqttClientUnsubscribeOptions options) =>
+            clients.SelectMany(client => client.ObserveUnsubscribe(options));
+
+        /// <summary>Unsubscribes each client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the unsubscribe options.</param>
+        /// <returns>The asynchronous unsubscribe-result sequence.</returns>
+        public IObservableAsync<MqttClientUnsubscribeResult> Unsubscribe(
+            Action<MqttClientUnsubscribeOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttClientUnsubscribeOptionsBuilder();
+            configure(builder);
+            return clients.Unsubscribe(builder.Build());
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Client/ResilientMqttClientOperationExtensions.cs
+++ b/src/MQTTnet.Rx.Client/ResilientMqttClientOperationExtensions.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Packets;
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Reactive.Signals;
+#else
+using ReactiveUI.Primitives.Signals;
+#endif
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Provides paired cold reactive wrappers for every resilient MQTT client operation.</summary>
+public static class ResilientMqttClientOperationExtensions
+{
+    /// <summary>Provides direct reactive resilient-client operations.</summary>
+    /// <param name="client">The resilient MQTT client.</param>
+    extension(IResilientMqttClient client)
+    {
+        /// <summary>Enqueues an application message when subscribed.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold enqueue operation.</returns>
+        public IObservable<RxUnit> Enqueue(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTask(() => client.EnqueueAsync(message));
+        }
+
+        /// <summary>Enqueues a resilient application message when subscribed.</summary>
+        /// <param name="message">The resilient application message.</param>
+        /// <returns>A cold enqueue operation.</returns>
+        public IObservable<RxUnit> Enqueue(ResilientMqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTask(() => client.EnqueueAsync(message));
+        }
+
+        /// <summary>Enqueues an application message through an asynchronous observable.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold asynchronous enqueue operation.</returns>
+        public IObservableAsync<RxUnit> ObserveEnqueue(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTaskSignal(() => client.EnqueueAsync(message));
+        }
+
+        /// <summary>Enqueues a resilient application message through an asynchronous observable.</summary>
+        /// <param name="message">The resilient application message.</param>
+        /// <returns>A cold asynchronous enqueue operation.</returns>
+        public IObservableAsync<RxUnit> ObserveEnqueue(ResilientMqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return FromTaskSignal(() => client.EnqueueAsync(message));
+        }
+
+        /// <summary>Sends a ping when subscribed.</summary>
+        /// <returns>A cold ping operation.</returns>
+        public IObservable<RxUnit> Ping() => FromTask(client.PingAsync);
+
+        /// <summary>Sends a ping through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous ping operation.</returns>
+        public IObservableAsync<RxUnit> ObservePing() => FromTaskSignal(client.PingAsync);
+
+        /// <summary>Starts the resilient client with prebuilt options.</summary>
+        /// <param name="options">The resilient-client options.</param>
+        /// <returns>A cold start operation.</returns>
+        public IObservable<RxUnit> Start(ResilientMqttClientOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTask(() => client.StartAsync(options));
+        }
+
+        /// <summary>Starts the resilient client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the resilient-client options.</param>
+        /// <returns>A cold start operation.</returns>
+        public IObservable<RxUnit> Start(Action<ResilientMqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new ResilientMqttClientOptionsBuilder();
+            configure(builder);
+            return client.Start(builder.Build());
+        }
+
+        /// <summary>Starts the resilient client asynchronously with prebuilt options.</summary>
+        /// <param name="options">The resilient-client options.</param>
+        /// <returns>A cold asynchronous start operation.</returns>
+        public IObservableAsync<RxUnit> ObserveStart(ResilientMqttClientOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return FromTaskSignal(() => client.StartAsync(options));
+        }
+
+        /// <summary>Starts the resilient client asynchronously with fluent option configuration.</summary>
+        /// <param name="configure">Configures the resilient-client options.</param>
+        /// <returns>A cold asynchronous start operation.</returns>
+        public IObservableAsync<RxUnit> ObserveStart(Action<ResilientMqttClientOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new ResilientMqttClientOptionsBuilder();
+            configure(builder);
+            return client.ObserveStart(builder.Build());
+        }
+
+        /// <summary>Stops the resilient client with a clean disconnect.</summary>
+        /// <returns>A cold stop operation.</returns>
+        public IObservable<RxUnit> Stop() => client.Stop(true);
+
+        /// <summary>Stops the resilient client.</summary>
+        /// <param name="cleanDisconnect">Whether to perform a clean MQTT disconnect.</param>
+        /// <returns>A cold stop operation.</returns>
+        public IObservable<RxUnit> Stop(bool cleanDisconnect) =>
+            FromTask(() => client.StopAsync(cleanDisconnect));
+
+        /// <summary>Stops the resilient client asynchronously with a clean disconnect.</summary>
+        /// <returns>A cold asynchronous stop operation.</returns>
+        public IObservableAsync<RxUnit> ObserveStop() => client.ObserveStop(true);
+
+        /// <summary>Stops the resilient client asynchronously.</summary>
+        /// <param name="cleanDisconnect">Whether to perform a clean MQTT disconnect.</param>
+        /// <returns>A cold asynchronous stop operation.</returns>
+        public IObservableAsync<RxUnit> ObserveStop(bool cleanDisconnect) =>
+            FromTaskSignal(() => client.StopAsync(cleanDisconnect));
+
+        /// <summary>Subscribes the resilient client when subscribed.</summary>
+        /// <param name="topicFilters">The topic filters.</param>
+        /// <returns>A cold subscribe operation.</returns>
+        public IObservable<RxUnit> Subscribe(IEnumerable<MqttTopicFilter> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return FromTask(() => client.SubscribeAsync(topicFilters));
+        }
+
+        /// <summary>Subscribes the resilient client through an asynchronous observable.</summary>
+        /// <param name="topicFilters">The topic filters.</param>
+        /// <returns>A cold asynchronous subscribe operation.</returns>
+        public IObservableAsync<RxUnit> ObserveSubscribe(IEnumerable<MqttTopicFilter> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return FromTaskSignal(() => client.SubscribeAsync(topicFilters));
+        }
+
+        /// <summary>Unsubscribes the resilient client when subscribed.</summary>
+        /// <param name="topics">The topic names.</param>
+        /// <returns>A cold unsubscribe operation.</returns>
+        public IObservable<RxUnit> Unsubscribe(IEnumerable<string> topics)
+        {
+            ArgumentNullException.ThrowIfNull(topics);
+            return FromTask(() => client.UnsubscribeAsync(topics));
+        }
+
+        /// <summary>Unsubscribes the resilient client through an asynchronous observable.</summary>
+        /// <param name="topics">The topic names.</param>
+        /// <returns>A cold asynchronous unsubscribe operation.</returns>
+        public IObservableAsync<RxUnit> ObserveUnsubscribe(IEnumerable<string> topics)
+        {
+            ArgumentNullException.ThrowIfNull(topics);
+            return FromTaskSignal(() => client.UnsubscribeAsync(topics));
+        }
+    }
+
+    /// <summary>Wraps a task as a cold observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold observable operation.</returns>
+    private static IObservable<RxUnit> FromTask(Func<Task> operation) => Signal.FromAsync(async () =>
+    {
+        await operation().ConfigureAwait(false);
+        return RxUnit.Default;
+    });
+
+    /// <summary>Wraps a task as a cold asynchronous observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold asynchronous observable operation.</returns>
+    private static IObservableAsync<RxUnit> FromTaskSignal(Func<Task> operation) =>
+        SignalAsync.FromAsync(async _ =>
+        {
+            await operation().ConfigureAwait(false);
+            return RxUnit.Default;
+        });
+}

--- a/src/MQTTnet.Rx.Client/ResilientMqttClientProperties.cs
+++ b/src/MQTTnet.Rx.Client/ResilientMqttClientProperties.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of every resilient MQTT client property.</summary>
+/// <param name="InternalClient">The underlying MQTTnet client.</param>
+/// <param name="IsConnected">Whether the client is connected.</param>
+/// <param name="IsStarted">Whether the resilient client is started.</param>
+/// <param name="Options">The current resilient-client options.</param>
+/// <param name="PendingApplicationMessagesCount">The pending application-message count.</param>
+public sealed record ResilientMqttClientProperties(
+    IMqttClient InternalClient,
+    bool IsConnected,
+    bool IsStarted,
+    ResilientMqttClientOptions? Options,
+    int PendingApplicationMessagesCount);

--- a/src/MQTTnet.Rx.Client/ResilientMqttClientPropertyExtensions.cs
+++ b/src/MQTTnet.Rx.Client/ResilientMqttClientPropertyExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI.Primitives.Async;
+#if REACTIVE_SHIM
+using ReactiveUI.Primitives.Reactive.Signals;
+#else
+using ReactiveUI.Primitives.Signals;
+#endif
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Client.Reactive;
+#else
+namespace MQTTnet.Rx.Client;
+#endif
+
+/// <summary>Provides cold reactive projections for every resilient MQTT client property.</summary>
+public static class ResilientMqttClientPropertyExtensions
+{
+    /// <summary>Provides resilient-client property projections.</summary>
+    /// <param name="client">The resilient MQTT client.</param>
+    extension(IResilientMqttClient client)
+    {
+        /// <summary>Captures every resilient-client property immediately.</summary>
+        /// <returns>The current resilient-client property snapshot.</returns>
+        public ResilientMqttClientProperties Properties() => new(
+            client.InternalClient,
+            client.IsConnected,
+            client.IsStarted,
+            client.Options,
+            client.PendingApplicationMessagesCount);
+
+        /// <summary>Reads an arbitrary resilient-client property once per subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<T> Property<T>(Func<IResilientMqttClient, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return Signal.FromAsync(_ => Task.FromResult(selector(client)));
+        }
+
+        /// <summary>Reads an arbitrary resilient-client property once per asynchronous subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<T> ObserveProperty<T>(Func<IResilientMqttClient, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return SignalAsync.FromAsync(_ => new ValueTask<T>(selector(client)));
+        }
+
+        /// <summary>Captures every resilient-client property once per subscription.</summary>
+        /// <returns>A cold resilient-client property snapshot.</returns>
+        public IObservable<ResilientMqttClientProperties> PropertySnapshots() =>
+            client.Property(static value => value.Properties());
+
+        /// <summary>Captures every resilient-client property once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous resilient-client property snapshot.</returns>
+        public IObservableAsync<ResilientMqttClientProperties> ObservePropertySnapshots() =>
+            client.ObserveProperty(static value => value.Properties());
+
+        /// <summary>Observes subscription changes synchronously.</summary>
+        /// <returns>A synchronous observable sequence of subscription changes.</returns>
+        public IObservable<SubscriptionsChangedEventArgs> SubscriptionsChanged() =>
+            Signal.Create<SubscriptionsChangedEventArgs>(observer =>
+                client.RegisterSubscriptionsChangedHandler((eventArgs, _) =>
+                {
+                    observer.OnNext(eventArgs);
+                    return ValueTask.CompletedTask;
+                }));
+    }
+}

--- a/src/MQTTnet.Rx.Server.Reactive/MQTTnet.Rx.Server.Reactive.csproj
+++ b/src/MQTTnet.Rx.Server.Reactive/MQTTnet.Rx.Server.Reactive.csproj
@@ -28,5 +28,6 @@
     <Using Include="ReactiveUI.Primitives.Reactive" />
     <Using Include="ReactiveUI.Primitives.Reactive.Signals" />
     <Using Include="ReactiveUI.Primitives.Reactive.Signals.Signal" Alias="SignalFactory" />
+    <Using Include="System.Reactive.Unit" Alias="RxVoid" />
   </ItemGroup>
 </Project>

--- a/src/MQTTnet.Rx.Server/Create.cs
+++ b/src/MQTTnet.Rx.Server/Create.cs
@@ -58,8 +58,7 @@ public static class Create
             async (observer, cancellationToken) =>
         {
             var session = await lifetime.AcquireAsync(cancellationToken).ConfigureAwait(false);
-            await observer.OnNextAsync((session.Server, session), cancellationToken).ConfigureAwait(false);
-            return session;
+            return await NotifyObserverAsync(observer, session, cancellationToken).ConfigureAwait(false);
         }).Retry(MaximumServerRetries);
     }
 
@@ -118,8 +117,7 @@ public static class Create
             async (observer, cancellationToken) =>
         {
             var session = await lifetime.AcquireAsync(cancellationToken).ConfigureAwait(false);
-            await observer.OnNextAsync((session.Server, session), cancellationToken).ConfigureAwait(false);
-            return session;
+            return await NotifyObserverAsync(observer, session, cancellationToken).ConfigureAwait(false);
         }).Retry(MaximumServerRetries);
     }
 
@@ -140,6 +138,28 @@ public static class Create
         {
             session.Dispose();
             throw;
+        }
+    }
+
+    /// <summary>Notifies an asynchronous observer and releases the session if the observer rejects it.</summary>
+    /// <param name="observer">The observer receiving the server session.</param>
+    /// <param name="session">The acquired server session.</param>
+    /// <param name="cancellationToken">Cancels the observer notification.</param>
+    /// <returns>The accepted server session.</returns>
+    private static async ValueTask<MqttServerSession> NotifyObserverAsync(
+        IObserverAsync<(MqttServer Server, MqttServerSession Disposable)> observer,
+        MqttServerSession session,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await observer.OnNextAsync((session.Server, session), cancellationToken).ConfigureAwait(false);
+            return session;
+        }
+        catch (Exception exception)
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+            return await ValueTask.FromException<MqttServerSession>(exception).ConfigureAwait(false);
         }
     }
 

--- a/src/MQTTnet.Rx.Server/CreateObservable.cs
+++ b/src/MQTTnet.Rx.Server/CreateObservable.cs
@@ -11,6 +11,40 @@ namespace MQTTnet.Rx.Server;
 /// <summary>Creates observable projections for asynchronous events.</summary>
 internal static class CreateObservable
 {
+    /// <summary>Wraps a cancellable task result as a cold observable operation.</summary>
+    /// <typeparam name="T">The operation result type.</typeparam>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold observable operation.</returns>
+    internal static IObservable<T> FromTask<T>(Func<CancellationToken, Task<T>> operation) =>
+        SignalFactory.FromAsync(operation);
+
+    /// <summary>Wraps a cancellable task as a cold observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold observable operation.</returns>
+    internal static IObservable<RxVoid> FromTask(Func<CancellationToken, Task> operation) =>
+        SignalFactory.FromAsync(async cancellationToken =>
+        {
+            await operation(cancellationToken).ConfigureAwait(false);
+            return RxVoid.Default;
+        });
+
+    /// <summary>Wraps a cancellable task result as a cold asynchronous observable operation.</summary>
+    /// <typeparam name="T">The operation result type.</typeparam>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold asynchronous observable operation.</returns>
+    internal static IObservableAsync<T> FromTaskSignal<T>(Func<CancellationToken, Task<T>> operation) =>
+        SignalAsync.FromAsync(cancellationToken => new ValueTask<T>(operation(cancellationToken)));
+
+    /// <summary>Wraps a cancellable task as a cold asynchronous observable operation.</summary>
+    /// <param name="operation">The task factory.</param>
+    /// <returns>A cold asynchronous observable operation.</returns>
+    internal static IObservableAsync<RxVoid> FromTaskSignal(Func<CancellationToken, Task> operation) =>
+        SignalAsync.FromAsync(async cancellationToken =>
+        {
+            await operation(cancellationToken).ConfigureAwait(false);
+            return RxVoid.Default;
+        });
+
     /// <summary>Creates a shared observable sequence from an asynchronous event.</summary>
     /// <typeparam name="T">The event argument type.</typeparam>
     /// <param name="addHandler">Adds an asynchronous event handler.</param>

--- a/src/MQTTnet.Rx.Server/MQTTnet.Rx.Server.csproj
+++ b/src/MQTTnet.Rx.Server/MQTTnet.Rx.Server.csproj
@@ -19,5 +19,6 @@
     <Using Include="ReactiveUI.Primitives.Disposables" />
     <Using Include="ReactiveUI.Primitives.Signals" />
     <Using Include="ReactiveUI.Primitives.Signals.Signal" Alias="SignalFactory" />
+    <Using Include="ReactiveUI.Primitives.RxVoid" Alias="RxVoid" />
   </ItemGroup>
 </Project>

--- a/src/MQTTnet.Rx.Server/MqttClientStatusExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttClientStatusExtensions.cs
@@ -1,0 +1,146 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides reactive operations, properties, and fluent configuration for broker client statuses.</summary>
+public static class MqttClientStatusExtensions
+{
+    /// <summary>Provides reactive client-status features.</summary>
+    /// <param name="client">The broker client status.</param>
+    extension(MqttClientStatus client)
+    {
+        /// <summary>Captures every public status property immediately.</summary>
+        /// <returns>The current status-property snapshot.</returns>
+        public MqttClientStatusProperties Properties() => new(
+            client.BytesReceived,
+            client.BytesSent,
+            client.ConnectedTimestamp,
+            client.RemoteEndPoint,
+            client.RemoteEndPoint.ToString(),
+            client.Id,
+            client.LastNonKeepAlivePacketReceivedTimestamp,
+            client.LastPacketReceivedTimestamp,
+            client.LastPacketSentTimestamp,
+            client.ProtocolVersion,
+            client.ReceivedApplicationMessagesCount,
+            client.ReceivedPacketsCount,
+            client.SentApplicationMessagesCount,
+            client.SentPacketsCount,
+            client.Session);
+
+        /// <summary>Reads an arbitrary status property once per subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<T> Property<T>(Func<MqttClientStatus, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTask(_ => Task.FromResult(selector(client)));
+        }
+
+        /// <summary>Reads an arbitrary status property once per asynchronous subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<T> ObserveProperty<T>(Func<MqttClientStatus, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTaskSignal(_ => Task.FromResult(selector(client)));
+        }
+
+        /// <summary>Captures every public status property once per subscription.</summary>
+        /// <returns>A cold status-property snapshot.</returns>
+        public IObservable<MqttClientStatusProperties> PropertySnapshots() =>
+            client.Property(static value => value.Properties());
+
+        /// <summary>Captures every public status property once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous status-property snapshot.</returns>
+        public IObservableAsync<MqttClientStatusProperties> ObservePropertySnapshots() =>
+            client.ObserveProperty(static value => value.Properties());
+
+        /// <summary>Disconnects this client when subscribed.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxVoid> Disconnect(MqttServerClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = client.DisconnectAsync(options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Disconnects this client with fluent option configuration.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxVoid> Disconnect(Action<MqttServerClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerClientDisconnectOptionsBuilder();
+            configure(builder);
+            return client.Disconnect(builder.Build());
+        }
+
+        /// <summary>Disconnects this client through an asynchronous observable.</summary>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDisconnect(MqttServerClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = client.DisconnectAsync(options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Disconnects this client asynchronously with fluent option configuration.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDisconnect(
+            Action<MqttServerClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerClientDisconnectOptionsBuilder();
+            configure(builder);
+            return client.ObserveDisconnect(builder.Build());
+        }
+
+        /// <summary>Resets statistics when subscribed.</summary>
+        /// <returns>A cold reset operation.</returns>
+        public IObservable<RxVoid> ResetStatisticsOperation() =>
+            CreateObservable.FromTask(_ =>
+            {
+                client.ResetStatistics();
+                return Task.CompletedTask;
+            });
+
+        /// <summary>Resets statistics through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous reset operation.</returns>
+        public IObservableAsync<RxVoid> ObserveResetStatistics() =>
+            CreateObservable.FromTaskSignal(_ =>
+            {
+                client.ResetStatistics();
+                return Task.CompletedTask;
+            });
+
+        /// <summary>Sets the associated session while preserving the client-status receiver.</summary>
+        /// <param name="session">The associated session.</param>
+        /// <returns>The original client status.</returns>
+        public MqttClientStatus WithSession(MqttSessionStatus session)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            client.Session = session;
+            return client;
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttClientStatusProperties.cs
+++ b/src/MQTTnet.Rx.Server/MqttClientStatusProperties.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using MQTTnet.Formatter;
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of all public MQTT client-status properties.</summary>
+/// <param name="BytesReceived">The received byte count.</param>
+/// <param name="BytesSent">The sent byte count.</param>
+/// <param name="ConnectedTimestamp">The connection timestamp.</param>
+/// <param name="RemoteEndPoint">The remote endpoint.</param>
+/// <param name="Endpoint">The remote endpoint text.</param>
+/// <param name="Id">The client identifier.</param>
+/// <param name="LastNonKeepAlivePacketReceivedTimestamp">The last non-keep-alive receive timestamp.</param>
+/// <param name="LastPacketReceivedTimestamp">The last packet receive timestamp.</param>
+/// <param name="LastPacketSentTimestamp">The last packet send timestamp.</param>
+/// <param name="ProtocolVersion">The negotiated protocol version.</param>
+/// <param name="ReceivedApplicationMessagesCount">The received application-message count.</param>
+/// <param name="ReceivedPacketsCount">The received packet count.</param>
+/// <param name="SentApplicationMessagesCount">The sent application-message count.</param>
+/// <param name="SentPacketsCount">The sent packet count.</param>
+/// <param name="Session">The associated session status.</param>
+public sealed record MqttClientStatusProperties(
+    long BytesReceived,
+    long BytesSent,
+    DateTimeOffset ConnectedTimestamp,
+    EndPoint? RemoteEndPoint,
+    string? Endpoint,
+    string Id,
+    DateTimeOffset LastNonKeepAlivePacketReceivedTimestamp,
+    DateTimeOffset LastPacketReceivedTimestamp,
+    DateTimeOffset LastPacketSentTimestamp,
+    MqttProtocolVersion ProtocolVersion,
+    long ReceivedApplicationMessagesCount,
+    long ReceivedPacketsCount,
+    long SentApplicationMessagesCount,
+    long SentPacketsCount,
+    MqttSessionStatus Session);

--- a/src/MQTTnet.Rx.Server/MqttPropertySnapshot.cs
+++ b/src/MQTTnet.Rx.Server/MqttPropertySnapshot.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Copies non-generic MQTTnet property dictionaries into immutable snapshots.</summary>
+internal static class MqttPropertySnapshot
+{
+    /// <summary>Copies a dictionary at subscription time.</summary>
+    /// <param name="source">The source dictionary.</param>
+    /// <returns>An independent read-only snapshot.</returns>
+    internal static IReadOnlyDictionary<object, object?> Copy(IDictionary source)
+    {
+        var snapshot = new Dictionary<object, object?>(source.Count);
+        foreach (DictionaryEntry item in source)
+        {
+            snapshot[item.Key] = item.Value;
+        }
+
+        return snapshot;
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttServerConfigurationExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerConfigurationExtensions.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides receiver-preserving fluent MQTT server configuration.</summary>
+public static class MqttServerConfigurationExtensions
+{
+    /// <summary>Provides direct server configuration.</summary>
+    /// <param name="server">The MQTT server.</param>
+    extension(MqttServer server)
+    {
+        /// <summary>Sets whether the server accepts new connections.</summary>
+        /// <param name="value">Whether new connections are accepted.</param>
+        /// <returns>The original server.</returns>
+        public MqttServer WithAcceptNewConnections(bool value)
+        {
+            server.AcceptNewConnections = value;
+            return server;
+        }
+
+        /// <summary>Adds or replaces one server session item.</summary>
+        /// <param name="key">The session-item key.</param>
+        /// <param name="value">The session-item value.</param>
+        /// <returns>The original server.</returns>
+        public MqttServer WithServerSessionItem(object key, object value)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(value);
+            server.ServerSessionItems[key] = value;
+            return server;
+        }
+
+        /// <summary>Removes one server session item.</summary>
+        /// <param name="key">The session-item key.</param>
+        /// <returns>The original server.</returns>
+        public MqttServer WithoutServerSessionItem(object key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            server.ServerSessionItems.Remove(key);
+            return server;
+        }
+
+        /// <summary>Clears every server session item.</summary>
+        /// <returns>The original server.</returns>
+        public MqttServer ClearServerSessionItems()
+        {
+            server.ServerSessionItems.Clear();
+            return server;
+        }
+
+        /// <summary>Runs arbitrary direct configuration while preserving the server receiver.</summary>
+        /// <param name="configure">Configures the server.</param>
+        /// <returns>The original server.</returns>
+        public MqttServer ConfigureServer(Action<MqttServer> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            configure(server);
+            return server;
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttServerExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerExtensions.cs
@@ -17,6 +17,20 @@ public static class MqttServerExtensions
     /// <param name="server">The MQTT server whose events are observed.</param>
     extension(MqttServer server)
     {
+        /// <summary>Observes application messages that were enqueued or dropped for a client.</summary>
+        /// <returns>An observable event sequence.</returns>
+        public IObservable<ApplicationMessageEnqueuedEventArgs> ApplicationMessageEnqueuedOrDropped() =>
+            CreateObservable.FromAsyncEvent<ApplicationMessageEnqueuedEventArgs>(
+                handler => server.ApplicationMessageEnqueuedOrDroppedAsync += handler,
+                handler => server.ApplicationMessageEnqueuedOrDroppedAsync -= handler);
+
+        /// <summary>Observes application messages that were enqueued or dropped for a client asynchronously.</summary>
+        /// <returns>An asynchronous observable event sequence.</returns>
+        public IObservableAsync<ApplicationMessageEnqueuedEventArgs> ObserveApplicationMessageEnqueuedOrDropped() =>
+            CreateObservable.FromAsyncEventSignal<ApplicationMessageEnqueuedEventArgs>(
+                handler => server.ApplicationMessageEnqueuedOrDroppedAsync += handler,
+                handler => server.ApplicationMessageEnqueuedOrDroppedAsync -= handler);
+
         /// <summary>Observes the associated MQTT server event.</summary>
         /// <returns>An observable event sequence.</returns>
         public IObservable<ApplicationMessageNotConsumedEventArgs> ApplicationMessageNotConsumed() =>
@@ -213,6 +227,20 @@ public static class MqttServerExtensions
             CreateObservable.FromAsyncEventSignal<EventArgs>(
                 handler => server.PreparingSessionAsync += handler,
                 handler => server.PreparingSessionAsync -= handler);
+
+        /// <summary>Observes queued application messages that were overwritten.</summary>
+        /// <returns>An observable event sequence.</returns>
+        public IObservable<QueueMessageOverwrittenEventArgs> QueuedApplicationMessageOverwritten() =>
+            CreateObservable.FromAsyncEvent<QueueMessageOverwrittenEventArgs>(
+                handler => server.QueuedApplicationMessageOverwrittenAsync += handler,
+                handler => server.QueuedApplicationMessageOverwrittenAsync -= handler);
+
+        /// <summary>Observes queued application messages that were overwritten asynchronously.</summary>
+        /// <returns>An asynchronous observable event sequence.</returns>
+        public IObservableAsync<QueueMessageOverwrittenEventArgs> ObserveQueuedApplicationMessageOverwritten() =>
+            CreateObservable.FromAsyncEventSignal<QueueMessageOverwrittenEventArgs>(
+                handler => server.QueuedApplicationMessageOverwrittenAsync += handler,
+                handler => server.QueuedApplicationMessageOverwrittenAsync -= handler);
 
         /// <summary>Observes the associated MQTT server event.</summary>
         /// <returns>An observable event sequence.</returns>

--- a/src/MQTTnet.Rx.Server/MqttServerOperationExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerOperationExtensions.cs
@@ -1,0 +1,419 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Packets;
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides cold reactive wrappers for every public MQTT server operation.</summary>
+public static class MqttServerOperationExtensions
+{
+    /// <summary>Provides reactive operations for an MQTT server.</summary>
+    /// <param name="server">The MQTT server.</param>
+    extension(MqttServer server)
+    {
+        /// <summary>Deletes every retained message when subscribed.</summary>
+        /// <returns>A cold delete operation.</returns>
+        public IObservable<RxVoid> DeleteRetainedMessages() =>
+            CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.DeleteRetainedMessagesAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Deletes every retained message through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous delete operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDeleteRetainedMessages() =>
+            CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.DeleteRetainedMessagesAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Disconnects a client when subscribed.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxVoid> DisconnectClient(string clientId, MqttServerClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.DisconnectClientAsync(clientId, options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Disconnects a client with fluent disconnect-option configuration.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold disconnect operation.</returns>
+        public IObservable<RxVoid> DisconnectClient(
+            string clientId,
+            Action<MqttServerClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerClientDisconnectOptionsBuilder();
+            configure(builder);
+            return server.DisconnectClient(clientId, builder.Build());
+        }
+
+        /// <summary>Disconnects a client through an asynchronous observable.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="options">The disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDisconnectClient(
+            string clientId,
+            MqttServerClientDisconnectOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.DisconnectClientAsync(clientId, options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Disconnects a client asynchronously with fluent disconnect-option configuration.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>A cold asynchronous disconnect operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDisconnectClient(
+            string clientId,
+            Action<MqttServerClientDisconnectOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerClientDisconnectOptionsBuilder();
+            configure(builder);
+            return server.ObserveDisconnectClient(clientId, builder.Build());
+        }
+
+        /// <summary>Gets a point-in-time client-status collection when subscribed.</summary>
+        /// <returns>A cold client query.</returns>
+        public IObservable<IList<MqttClientStatus>> GetClients() =>
+            CreateObservable.FromTask<IList<MqttClientStatus>>(cancellationToken =>
+            {
+                var operation = server.GetClientsAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Gets a point-in-time client-status collection asynchronously.</summary>
+        /// <returns>A cold asynchronous client query.</returns>
+        public IObservableAsync<IList<MqttClientStatus>> ObserveClients() =>
+            CreateObservable.FromTaskSignal<IList<MqttClientStatus>>(cancellationToken =>
+            {
+                var operation = server.GetClientsAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Gets one retained message when subscribed.</summary>
+        /// <param name="topic">The retained-message topic.</param>
+        /// <returns>A cold retained-message query.</returns>
+        public IObservable<MqttApplicationMessage> GetRetainedMessage(string topic)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return CreateObservable.FromTask<MqttApplicationMessage>(cancellationToken =>
+            {
+                var operation = server.GetRetainedMessageAsync(topic);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Gets one retained message asynchronously.</summary>
+        /// <param name="topic">The retained-message topic.</param>
+        /// <returns>A cold asynchronous retained-message query.</returns>
+        public IObservableAsync<MqttApplicationMessage> ObserveRetainedMessage(string topic)
+        {
+            ArgumentNullException.ThrowIfNull(topic);
+            return CreateObservable.FromTaskSignal<MqttApplicationMessage>(cancellationToken =>
+            {
+                var operation = server.GetRetainedMessageAsync(topic);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Gets every retained message when subscribed.</summary>
+        /// <returns>A cold retained-message query.</returns>
+        public IObservable<IList<MqttApplicationMessage>> GetRetainedMessages() =>
+            CreateObservable.FromTask<IList<MqttApplicationMessage>>(cancellationToken =>
+            {
+                var operation = server.GetRetainedMessagesAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Gets every retained message asynchronously.</summary>
+        /// <returns>A cold asynchronous retained-message query.</returns>
+        public IObservableAsync<IList<MqttApplicationMessage>> ObserveRetainedMessages() =>
+            CreateObservable.FromTaskSignal<IList<MqttApplicationMessage>>(cancellationToken =>
+            {
+                var operation = server.GetRetainedMessagesAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Gets a session status when subscribed.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <returns>A cold session query.</returns>
+        public IObservable<MqttSessionStatus> GetSession(string clientId)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            return CreateObservable.FromTask<MqttSessionStatus>(cancellationToken =>
+            {
+                var operation = server.GetSessionAsync(clientId);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Gets a session status asynchronously.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <returns>A cold asynchronous session query.</returns>
+        public IObservableAsync<MqttSessionStatus> ObserveSession(string clientId)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            return CreateObservable.FromTaskSignal<MqttSessionStatus>(cancellationToken =>
+            {
+                var operation = server.GetSessionAsync(clientId);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Gets every session status when subscribed.</summary>
+        /// <returns>A cold session query.</returns>
+        public IObservable<IList<MqttSessionStatus>> GetSessions() =>
+            CreateObservable.FromTask<IList<MqttSessionStatus>>(cancellationToken =>
+            {
+                var operation = server.GetSessionsAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Gets every session status asynchronously.</summary>
+        /// <returns>A cold asynchronous session query.</returns>
+        public IObservableAsync<IList<MqttSessionStatus>> ObserveSessions() =>
+            CreateObservable.FromTaskSignal<IList<MqttSessionStatus>>(cancellationToken =>
+            {
+                var operation = server.GetSessionsAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Injects an application message when subscribed.</summary>
+        /// <param name="message">The injected application message.</param>
+        /// <returns>A cold injection operation.</returns>
+        public IObservable<RxVoid> InjectApplicationMessageOperation(InjectedMqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.InjectApplicationMessage(message, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Injects an application message through an asynchronous observable.</summary>
+        /// <param name="message">The injected application message.</param>
+        /// <returns>A cold asynchronous injection operation.</returns>
+        public IObservableAsync<RxVoid> ObserveInjectApplicationMessage(InjectedMqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.InjectApplicationMessage(message, cancellationToken);
+                return operation;
+            });
+        }
+
+        /// <summary>Starts the server when subscribed.</summary>
+        /// <returns>A cold start operation.</returns>
+        public IObservable<RxVoid> Start() => CreateObservable.FromTask(cancellationToken =>
+        {
+            var operation = server.StartAsync();
+            return operation.WaitAsync(cancellationToken);
+        });
+
+        /// <summary>Starts the server through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous start operation.</returns>
+        public IObservableAsync<RxVoid> ObserveStart() => CreateObservable.FromTaskSignal(cancellationToken =>
+        {
+            var operation = server.StartAsync();
+            return operation.WaitAsync(cancellationToken);
+        });
+
+        /// <summary>Stops the server using default options when subscribed.</summary>
+        /// <returns>A cold stop operation.</returns>
+        public IObservable<RxVoid> Stop() => server.Stop(new MqttServerStopOptions());
+
+        /// <summary>Stops the server when subscribed.</summary>
+        /// <param name="options">The stop options.</param>
+        /// <returns>A cold stop operation.</returns>
+        public IObservable<RxVoid> Stop(MqttServerStopOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.StopAsync(options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Stops the server with fluent stop-option configuration.</summary>
+        /// <param name="configure">Configures the stop options.</param>
+        /// <returns>A cold stop operation.</returns>
+        public IObservable<RxVoid> Stop(Action<MqttServerStopOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerStopOptionsBuilder();
+            configure(builder);
+            return server.Stop(builder.Build());
+        }
+
+        /// <summary>Stops the server asynchronously using default options.</summary>
+        /// <returns>A cold asynchronous stop operation.</returns>
+        public IObservableAsync<RxVoid> ObserveStop() => server.ObserveStop(new MqttServerStopOptions());
+
+        /// <summary>Stops the server through an asynchronous observable.</summary>
+        /// <param name="options">The stop options.</param>
+        /// <returns>A cold asynchronous stop operation.</returns>
+        public IObservableAsync<RxVoid> ObserveStop(MqttServerStopOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.StopAsync(options);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Stops the server asynchronously with fluent stop-option configuration.</summary>
+        /// <param name="configure">Configures the stop options.</param>
+        /// <returns>A cold asynchronous stop operation.</returns>
+        public IObservableAsync<RxVoid> ObserveStop(Action<MqttServerStopOptionsBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttServerStopOptionsBuilder();
+            configure(builder);
+            return server.ObserveStop(builder.Build());
+        }
+
+        /// <summary>Subscribes a client to topic filters when subscribed.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="topicFilters">The topic filters.</param>
+        /// <returns>A cold subscribe operation.</returns>
+        public IObservable<RxVoid> SubscribeClient(string clientId, ICollection<MqttTopicFilter> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.SubscribeAsync(clientId, topicFilters);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Subscribes a client using one fluently configured topic filter.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="configure">Configures the topic filter.</param>
+        /// <returns>A cold subscribe operation.</returns>
+        public IObservable<RxVoid> SubscribeClient(string clientId, Action<MqttTopicFilterBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttTopicFilterBuilder();
+            configure(builder);
+            return server.SubscribeClient(clientId, [builder.Build()]);
+        }
+
+        /// <summary>Subscribes a client to topic filters asynchronously.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="topicFilters">The topic filters.</param>
+        /// <returns>A cold asynchronous subscribe operation.</returns>
+        public IObservableAsync<RxVoid> ObserveSubscribeClient(
+            string clientId,
+            ICollection<MqttTopicFilter> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.SubscribeAsync(clientId, topicFilters);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Subscribes a client asynchronously using one fluently configured topic filter.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="configure">Configures the topic filter.</param>
+        /// <returns>A cold asynchronous subscribe operation.</returns>
+        public IObservableAsync<RxVoid> ObserveSubscribeClient(
+            string clientId,
+            Action<MqttTopicFilterBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            var builder = new MqttTopicFilterBuilder();
+            configure(builder);
+            return server.ObserveSubscribeClient(clientId, [builder.Build()]);
+        }
+
+        /// <summary>Unsubscribes a client from topic filters when subscribed.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="topicFilters">The topic names.</param>
+        /// <returns>A cold unsubscribe operation.</returns>
+        public IObservable<RxVoid> UnsubscribeClient(string clientId, ICollection<string> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.UnsubscribeAsync(clientId, topicFilters);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Unsubscribes a client from topic filters asynchronously.</summary>
+        /// <param name="clientId">The client identifier.</param>
+        /// <param name="topicFilters">The topic names.</param>
+        /// <returns>A cold asynchronous unsubscribe operation.</returns>
+        public IObservableAsync<RxVoid> ObserveUnsubscribeClient(
+            string clientId,
+            ICollection<string> topicFilters)
+        {
+            ArgumentNullException.ThrowIfNull(clientId);
+            ArgumentNullException.ThrowIfNull(topicFilters);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.UnsubscribeAsync(clientId, topicFilters);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Updates one retained message when subscribed.</summary>
+        /// <param name="message">The retained application message.</param>
+        /// <returns>A cold retained-message update.</returns>
+        public IObservable<RxVoid> UpdateRetainedMessage(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = server.UpdateRetainedMessageAsync(message);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Updates one retained message through an asynchronous observable.</summary>
+        /// <param name="message">The retained application message.</param>
+        /// <returns>A cold asynchronous retained-message update.</returns>
+        public IObservableAsync<RxVoid> ObserveUpdateRetainedMessage(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = server.UpdateRetainedMessageAsync(message);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttServerOptionsConfigurationExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerOptionsConfigurationExtensions.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides complete receiver-preserving access to MQTT server option objects.</summary>
+public static class MqttServerOptionsConfigurationExtensions
+{
+    /// <summary>Provides complete direct access to disconnect options.</summary>
+    /// <param name="builder">The disconnect-options builder.</param>
+    extension(MqttServerClientDisconnectOptionsBuilder builder)
+    {
+        /// <summary>Configures the underlying disconnect options while preserving the builder receiver.</summary>
+        /// <param name="configure">Configures the disconnect options.</param>
+        /// <returns>The original builder.</returns>
+        public MqttServerClientDisconnectOptionsBuilder ConfigureOptions(
+            Action<MqttServerClientDisconnectOptions> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            configure(builder.Build());
+            return builder;
+        }
+    }
+
+    /// <summary>Provides complete direct access to server options not covered by MQTTnet's named builder methods.</summary>
+    /// <param name="builder">The server-options builder.</param>
+    extension(MqttServerOptionsBuilder builder)
+    {
+        /// <summary>Configures the underlying server options while preserving the builder receiver.</summary>
+        /// <param name="configure">Configures the server options.</param>
+        /// <returns>The original builder.</returns>
+        public MqttServerOptionsBuilder ConfigureOptions(Action<MqttServerOptions> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            configure(builder.Build());
+            return builder;
+        }
+    }
+
+    /// <summary>Provides complete direct access to stop options.</summary>
+    /// <param name="builder">The stop-options builder.</param>
+    extension(MqttServerStopOptionsBuilder builder)
+    {
+        /// <summary>Configures the underlying stop options while preserving the builder receiver.</summary>
+        /// <param name="configure">Configures the stop options.</param>
+        /// <returns>The original builder.</returns>
+        public MqttServerStopOptionsBuilder ConfigureOptions(Action<MqttServerStopOptions> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            configure(builder.Build());
+            return builder;
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttServerProperties.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerProperties.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of all public MQTT server properties.</summary>
+/// <param name="AcceptNewConnections">Whether the server accepts new connections.</param>
+/// <param name="IsStarted">Whether the server is started.</param>
+/// <param name="ServerSessionItems">A copy of the server session-item collection.</param>
+public sealed record MqttServerProperties(
+    bool AcceptNewConnections,
+    bool IsStarted,
+    IReadOnlyDictionary<object, object?> ServerSessionItems);

--- a/src/MQTTnet.Rx.Server/MqttServerPropertyExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerPropertyExtensions.cs
@@ -1,0 +1,298 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides cold reactive projections for every public MQTT server property.</summary>
+public static class MqttServerPropertyExtensions
+{
+    /// <summary>Provides property projections for an MQTT server.</summary>
+    /// <param name="server">The MQTT server.</param>
+    extension(MqttServer server)
+    {
+        /// <summary>Captures all public server properties immediately.</summary>
+        /// <returns>The current server-property snapshot.</returns>
+        public MqttServerProperties Properties() => new(
+            server.AcceptNewConnections,
+            server.IsStarted,
+            MqttPropertySnapshot.Copy(server.ServerSessionItems));
+
+        /// <summary>Reads an arbitrary server property once per subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<T> Property<T>(Func<MqttServer, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTask(_ => Task.FromResult(selector(server)));
+        }
+
+        /// <summary>Reads an arbitrary server property once per asynchronous subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<T> ObserveProperty<T>(Func<MqttServer, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTaskSignal(_ => Task.FromResult(selector(server)));
+        }
+
+        /// <summary>Captures all public server properties once per subscription.</summary>
+        /// <returns>A cold server-property snapshot.</returns>
+        public IObservable<MqttServerProperties> PropertySnapshots() =>
+            server.Property(static value => value.Properties());
+
+        /// <summary>Captures all public server properties once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous server-property snapshot.</returns>
+        public IObservableAsync<MqttServerProperties> ObservePropertySnapshots() =>
+            server.ObserveProperty(static value => value.Properties());
+
+        /// <summary>Reads whether new connections are accepted once per subscription.</summary>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<bool> AcceptNewConnectionsValue() =>
+            server.Property(static value => value.AcceptNewConnections);
+
+        /// <summary>Reads whether new connections are accepted once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<bool> ObserveAcceptNewConnections() =>
+            server.ObserveProperty(static value => value.AcceptNewConnections);
+
+        /// <summary>Copies server session items once per subscription.</summary>
+        /// <returns>A cold session-item snapshot.</returns>
+        public IObservable<IReadOnlyDictionary<object, object?>> ServerSessionItemsSnapshot() =>
+            server.Property(static value => MqttPropertySnapshot.Copy(value.ServerSessionItems));
+
+        /// <summary>Copies server session items once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous session-item snapshot.</returns>
+        public IObservableAsync<IReadOnlyDictionary<object, object?>> ObserveServerSessionItemsSnapshot() =>
+            server.ObserveProperty(static value => MqttPropertySnapshot.Copy(value.ServerSessionItems));
+
+        /// <summary>Emits the current started state and every subsequent lifecycle transition.</summary>
+        /// <returns>A lifecycle-state sequence.</returns>
+        public IObservable<bool> IsStartedChanges() =>
+            SignalFactory.Create<bool>(observer => new ServerStateSubscription(server, observer));
+
+        /// <summary>Emits the current started state and every subsequent lifecycle transition asynchronously.</summary>
+        /// <returns>An asynchronous lifecycle-state sequence.</returns>
+        public IObservableAsync<bool> ObserveIsStartedChanges() =>
+            SignalAsync.Create<bool>(async (observer, cancellationToken) =>
+            {
+                var subscription = new ServerStateAsyncSubscription(server, observer, cancellationToken);
+                await subscription.InitializeAsync().ConfigureAwait(false);
+                return subscription;
+            });
+    }
+
+    /// <summary>Serializes and owns a synchronous lifecycle-state subscription.</summary>
+    private sealed class ServerStateSubscription : IDisposable
+    {
+        /// <summary>Serializes notifications and state changes.</summary>
+#if NET9_0_OR_GREATER
+        private readonly Lock _gate = new();
+#else
+        private readonly object _gate = new();
+#endif
+
+        /// <summary>Receives lifecycle state.</summary>
+        private readonly IObserver<bool> _observer;
+
+        /// <summary>The observed server.</summary>
+        private readonly MqttServer _server;
+
+        /// <summary>Tracks disposal.</summary>
+        private bool _disposed;
+
+        /// <summary>Tracks whether a state has been emitted.</summary>
+        private bool _hasValue;
+
+        /// <summary>Stores the last emitted state.</summary>
+        private bool _value;
+
+        /// <summary>Initializes a new instance of the <see cref="ServerStateSubscription"/> class.</summary>
+        /// <param name="server">The observed server.</param>
+        /// <param name="observer">The lifecycle observer.</param>
+        internal ServerStateSubscription(MqttServer server, IObserver<bool> observer)
+        {
+            _server = server;
+            _observer = observer;
+            lock (_gate)
+            {
+                server.StartedAsync += OnStartedAsync;
+                server.StoppedAsync += OnStoppedAsync;
+                try
+                {
+                    Publish(server.IsStarted);
+                }
+                catch
+                {
+                    Dispose();
+                    throw;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+
+            _server.StartedAsync -= OnStartedAsync;
+            _server.StoppedAsync -= OnStoppedAsync;
+        }
+
+        /// <summary>Handles a server started event.</summary>
+        /// <param name="_">The unused event arguments.</param>
+        /// <returns>A completed task.</returns>
+        private Task OnStartedAsync(EventArgs _)
+        {
+            Publish(true);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Handles a server stopped event.</summary>
+        /// <param name="_">The unused event arguments.</param>
+        /// <returns>A completed task.</returns>
+        private Task OnStoppedAsync(EventArgs _)
+        {
+            Publish(false);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Publishes one distinct serialized state.</summary>
+        /// <param name="value">The lifecycle state.</param>
+        private void Publish(bool value)
+        {
+            lock (_gate)
+            {
+                if (_disposed || (_hasValue && _value == value))
+                {
+                    return;
+                }
+
+                _hasValue = true;
+                _value = value;
+                _observer.OnNext(value);
+            }
+        }
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ServerStateAsyncSubscription"/> class.</summary>
+    /// <param name="server">The observed server.</param>
+    /// <param name="observer">The lifecycle observer.</param>
+    /// <param name="cancellationToken">Cancels notifications.</param>
+    private sealed class ServerStateAsyncSubscription(
+        MqttServer server,
+        IObserverAsync<bool> observer,
+        CancellationToken cancellationToken) : IAsyncDisposable
+    {
+        /// <summary>Serializes notifications.</summary>
+        private readonly Create.LifecycleGate _delivery = new();
+
+        /// <summary>Signals completion of the initial notification.</summary>
+        private readonly TaskCompletionSource _initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Tracks disposal.</summary>
+        private bool _disposed;
+
+        /// <summary>Tracks whether a state has been emitted.</summary>
+        private bool _hasValue;
+
+        /// <summary>Stores the last emitted state.</summary>
+        private bool _value;
+
+        /// <inheritdoc/>
+        public ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            _disposed = true;
+            server.StartedAsync -= OnStartedAsync;
+            server.StoppedAsync -= OnStoppedAsync;
+            _ = _initialized.TrySetResult();
+            return ValueTask.CompletedTask;
+        }
+
+        /// <summary>Attaches lifecycle handlers and emits the initial state first.</summary>
+        /// <returns>A value task that represents initialization.</returns>
+        internal async ValueTask InitializeAsync()
+        {
+            server.StartedAsync += OnStartedAsync;
+            server.StoppedAsync += OnStoppedAsync;
+            var initialized = false;
+            try
+            {
+                await PublishAsync(server.IsStarted).ConfigureAwait(false);
+                initialized = true;
+                _ = _initialized.TrySetResult();
+            }
+            finally
+            {
+                if (!initialized)
+                {
+                    await DisposeAsync().ConfigureAwait(false);
+                    _ = _initialized.TrySetResult();
+                }
+            }
+        }
+
+        /// <summary>Handles a server started event.</summary>
+        /// <param name="_">The unused event arguments.</param>
+        /// <returns>A task that represents the notification.</returns>
+        private Task OnStartedAsync(EventArgs _) => PublishAfterInitializationAsync(true);
+
+        /// <summary>Handles a server stopped event.</summary>
+        /// <param name="_">The unused event arguments.</param>
+        /// <returns>A task that represents the notification.</returns>
+        private Task OnStoppedAsync(EventArgs _) => PublishAfterInitializationAsync(false);
+
+        /// <summary>Publishes a lifecycle state after the initial notification.</summary>
+        /// <param name="value">The lifecycle state.</param>
+        /// <returns>A task that represents the notification.</returns>
+        private async Task PublishAfterInitializationAsync(bool value)
+        {
+            await _initialized.Task.ConfigureAwait(false);
+            await PublishAsync(value).ConfigureAwait(false);
+        }
+
+        /// <summary>Publishes one distinct serialized lifecycle state.</summary>
+        /// <param name="value">The lifecycle state.</param>
+        /// <returns>A value task that represents the notification.</returns>
+        private async ValueTask PublishAsync(bool value)
+        {
+            await _delivery.EnterAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                if (_disposed || (_hasValue && _value == value))
+                {
+                    return;
+                }
+
+                _hasValue = true;
+                _value = value;
+                await observer.OnNextAsync(value, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _delivery.Exit();
+            }
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttServerSequenceConfigurationExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttServerSequenceConfigurationExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides fluent configuration for reactive MQTT server sequences.</summary>
+public static class MqttServerSequenceConfigurationExtensions
+{
+    /// <summary>Provides fluent configuration for synchronous MQTT server sequences.</summary>
+    /// <param name="servers">The server sequence.</param>
+    extension(IObservable<MqttServer> servers)
+    {
+        /// <summary>Configures every emitted server and preserves the sequence.</summary>
+        /// <param name="configure">Configures each server.</param>
+        /// <returns>The configured server sequence.</returns>
+        public IObservable<MqttServer> ConfigureServer(Action<MqttServer> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            return servers.Select(server => server.ConfigureServer(configure));
+        }
+    }
+
+    /// <summary>Provides fluent configuration for asynchronous MQTT server sequences.</summary>
+    /// <param name="servers">The asynchronous server sequence.</param>
+    extension(IObservableAsync<MqttServer> servers)
+    {
+        /// <summary>Configures every emitted server and preserves the asynchronous sequence.</summary>
+        /// <param name="configure">Configures each server.</param>
+        /// <returns>The configured asynchronous server sequence.</returns>
+        public IObservableAsync<MqttServer> ConfigureServer(Action<MqttServer> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            return servers.Select(server => server.ConfigureServer(configure));
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttSessionEnqueueResult.cs
+++ b/src/MQTTnet.Rx.Server/MqttSessionEnqueueResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Represents the result of trying to enqueue an application message.</summary>
+/// <param name="IsEnqueued">Whether the message was enqueued.</param>
+/// <param name="InjectResult">The MQTTnet injection result, when available.</param>
+public sealed record MqttSessionEnqueueResult(
+    bool IsEnqueued,
+    InjectMqttApplicationMessageResult? InjectResult);

--- a/src/MQTTnet.Rx.Server/MqttSessionStatusExtensions.cs
+++ b/src/MQTTnet.Rx.Server/MqttSessionStatusExtensions.cs
@@ -1,0 +1,197 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides reactive operations, properties, and fluent configuration for MQTT session statuses.</summary>
+public static class MqttSessionStatusExtensions
+{
+    /// <summary>Provides reactive session-status features.</summary>
+    /// <param name="session">The MQTT session status.</param>
+    extension(MqttSessionStatus session)
+    {
+        /// <summary>Captures every public session property immediately.</summary>
+        /// <returns>The current session-property snapshot.</returns>
+        public MqttSessionStatusProperties Properties() => new(
+            session.CreatedTimestamp,
+            session.DisconnectedTimestamp,
+            session.ExpiryInterval,
+            session.Id,
+            MqttPropertySnapshot.Copy(session.Items),
+            session.PendingApplicationMessagesCount);
+
+        /// <summary>Reads an arbitrary session property once per subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold property projection.</returns>
+        public IObservable<T> Property<T>(Func<MqttSessionStatus, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTask(_ => Task.FromResult(selector(session)));
+        }
+
+        /// <summary>Reads an arbitrary session property once per asynchronous subscription.</summary>
+        /// <typeparam name="T">The property value type.</typeparam>
+        /// <param name="selector">Selects the property value.</param>
+        /// <returns>A cold asynchronous property projection.</returns>
+        public IObservableAsync<T> ObserveProperty<T>(Func<MqttSessionStatus, T> selector)
+        {
+            ArgumentNullException.ThrowIfNull(selector);
+            return CreateObservable.FromTaskSignal(_ => Task.FromResult(selector(session)));
+        }
+
+        /// <summary>Captures every public session property once per subscription.</summary>
+        /// <returns>A cold session-property snapshot.</returns>
+        public IObservable<MqttSessionStatusProperties> PropertySnapshots() =>
+            session.Property(static value => value.Properties());
+
+        /// <summary>Captures every public session property once per asynchronous subscription.</summary>
+        /// <returns>A cold asynchronous session-property snapshot.</returns>
+        public IObservableAsync<MqttSessionStatusProperties> ObservePropertySnapshots() =>
+            session.ObserveProperty(static value => value.Properties());
+
+        /// <summary>Adds or replaces one session item.</summary>
+        /// <param name="key">The session-item key.</param>
+        /// <param name="value">The session-item value.</param>
+        /// <returns>The original session status.</returns>
+        public MqttSessionStatus WithSessionItem(object key, object value)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(value);
+            session.Items[key] = value;
+            return session;
+        }
+
+        /// <summary>Removes one session item.</summary>
+        /// <param name="key">The session-item key.</param>
+        /// <returns>The original session status.</returns>
+        public MqttSessionStatus WithoutSessionItem(object key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            session.Items.Remove(key);
+            return session;
+        }
+
+        /// <summary>Clears every session item.</summary>
+        /// <returns>The original session status.</returns>
+        public MqttSessionStatus ClearSessionItems()
+        {
+            session.Items.Clear();
+            return session;
+        }
+
+        /// <summary>Clears queued application messages when subscribed.</summary>
+        /// <returns>A cold clear operation.</returns>
+        public IObservable<RxVoid> ClearApplicationMessagesQueue() =>
+            CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = InvokeClearApplicationMessagesQueue(session);
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Clears queued application messages through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous clear operation.</returns>
+        public IObservableAsync<RxVoid> ObserveClearApplicationMessagesQueue() =>
+            CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = InvokeClearApplicationMessagesQueue(session);
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Deletes the session when subscribed.</summary>
+        /// <returns>A cold delete operation.</returns>
+        public IObservable<RxVoid> Delete() =>
+            CreateObservable.FromTask(cancellationToken =>
+            {
+                var operation = session.DeleteAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Deletes the session through an asynchronous observable.</summary>
+        /// <returns>A cold asynchronous delete operation.</returns>
+        public IObservableAsync<RxVoid> ObserveDelete() =>
+            CreateObservable.FromTaskSignal(cancellationToken =>
+            {
+                var operation = session.DeleteAsync();
+                return operation.WaitAsync(cancellationToken);
+            });
+
+        /// <summary>Delivers an application message immediately when subscribed.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold delivery operation.</returns>
+        public IObservable<InjectMqttApplicationMessageResult> DeliverApplicationMessage(
+            MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTask<InjectMqttApplicationMessageResult>(cancellationToken =>
+            {
+                var operation = session.DeliverApplicationMessageAsync(message);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Delivers an application message immediately through an asynchronous observable.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold asynchronous delivery operation.</returns>
+        public IObservableAsync<InjectMqttApplicationMessageResult> ObserveDeliverApplicationMessage(
+            MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTaskSignal<InjectMqttApplicationMessageResult>(cancellationToken =>
+            {
+                var operation = session.DeliverApplicationMessageAsync(message);
+                return operation.WaitAsync(cancellationToken);
+            });
+        }
+
+        /// <summary>Attempts to enqueue an application message when subscribed.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold enqueue attempt.</returns>
+        public IObservable<MqttSessionEnqueueResult> TryEnqueueApplicationMessage(MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTask(_ =>
+            {
+                var isEnqueued = session.TryEnqueueApplicationMessage(message, out var result);
+                return Task.FromResult(new MqttSessionEnqueueResult(isEnqueued, result));
+            });
+        }
+
+        /// <summary>Attempts to enqueue an application message through an asynchronous observable.</summary>
+        /// <param name="message">The application message.</param>
+        /// <returns>A cold asynchronous enqueue attempt.</returns>
+        public IObservableAsync<MqttSessionEnqueueResult> ObserveTryEnqueueApplicationMessage(
+            MqttApplicationMessage message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+            return CreateObservable.FromTaskSignal(_ =>
+            {
+                var isEnqueued = session.TryEnqueueApplicationMessage(message, out var result);
+                return Task.FromResult(new MqttSessionEnqueueResult(isEnqueued, result));
+            });
+        }
+
+    }
+
+    /// <summary>Normalizes MQTTnet implementations that throw before returning their operation task.</summary>
+    /// <param name="session">The session whose queue should be cleared.</param>
+    /// <returns>The clear operation or a faulted task.</returns>
+    private static Task InvokeClearApplicationMessagesQueue(MqttSessionStatus session)
+    {
+        try
+        {
+            return session.ClearApplicationMessagesQueueAsync();
+        }
+        catch (Exception exception)
+        {
+            return Task.FromException(exception);
+        }
+    }
+}

--- a/src/MQTTnet.Rx.Server/MqttSessionStatusProperties.cs
+++ b/src/MQTTnet.Rx.Server/MqttSessionStatusProperties.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Represents a point-in-time snapshot of all public MQTT session-status properties.</summary>
+/// <param name="CreatedTimestamp">The session creation timestamp.</param>
+/// <param name="DisconnectedTimestamp">The optional disconnection timestamp.</param>
+/// <param name="ExpiryInterval">The session expiry interval.</param>
+/// <param name="Id">The session identifier.</param>
+/// <param name="Items">A copy of the session items.</param>
+/// <param name="PendingApplicationMessagesCount">The pending application-message count.</param>
+public sealed record MqttSessionStatusProperties(
+    DateTimeOffset CreatedTimestamp,
+    DateTimeOffset? DisconnectedTimestamp,
+    uint ExpiryInterval,
+    string Id,
+    IReadOnlyDictionary<object, object?> Items,
+    long PendingApplicationMessagesCount);

--- a/src/MQTTnet.Rx.Server/ValidatingConnectionOperationExtensions.cs
+++ b/src/MQTTnet.Rx.Server/ValidatingConnectionOperationExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2026 Chris Pulman and contributors. All rights reserved.
+// Chris Pulman and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using MQTTnet.Server;
+using MQTTnet.Server.EnhancedAuthentication;
+
+#if REACTIVE_SHIM
+namespace MQTTnet.Rx.Server.Reactive;
+#else
+namespace MQTTnet.Rx.Server;
+#endif
+
+/// <summary>Provides reactive enhanced-authentication operations during connection validation.</summary>
+public static class ValidatingConnectionOperationExtensions
+{
+    /// <summary>Provides enhanced-authentication operations.</summary>
+    /// <param name="eventArgs">The connection-validation event arguments.</param>
+    extension(ValidatingConnectionEventArgs eventArgs)
+    {
+        /// <summary>Exchanges enhanced-authentication data when subscribed.</summary>
+        /// <param name="options">The authentication exchange options.</param>
+        /// <returns>A cold authentication exchange.</returns>
+        public IObservable<ExchangeEnhancedAuthenticationResult> ExchangeEnhancedAuthentication(
+            ExchangeEnhancedAuthenticationOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTask<ExchangeEnhancedAuthenticationResult>(cancellationToken =>
+                eventArgs.ExchangeEnhancedAuthenticationAsync(options, cancellationToken));
+        }
+
+        /// <summary>Exchanges enhanced-authentication data through an asynchronous observable.</summary>
+        /// <param name="options">The authentication exchange options.</param>
+        /// <returns>A cold asynchronous authentication exchange.</returns>
+        public IObservableAsync<ExchangeEnhancedAuthenticationResult> ObserveExchangeEnhancedAuthentication(
+            ExchangeEnhancedAuthenticationOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            return CreateObservable.FromTaskSignal<ExchangeEnhancedAuthenticationResult>(cancellationToken =>
+                eventArgs.ExchangeEnhancedAuthenticationAsync(options, cancellationToken));
+        }
+    }
+}

--- a/src/MQTTnet.Rx.slnx
+++ b/src/MQTTnet.Rx.slnx
@@ -12,6 +12,7 @@
   </Folder>
   <Folder Name="/Reactive/">
     <Project Path="MQTTnet.Rx.ABPlc.Reactive/MQTTnet.Rx.ABPlc.Reactive.csproj" />
+    <Project Path="MQTTnet.Rx.AspNetCore.Reactive/MQTTnet.Rx.AspNetCore.Reactive.csproj" />
     <Project Path="MQTTnet.Rx.Client.Reactive/MQTTnet.Rx.Client.Reactive.csproj" />
     <Project Path="MQTTnet.Rx.Mitsubishi.Reactive/MQTTnet.Rx.Mitsubishi.Reactive.csproj" />
     <Project Path="MQTTnet.Rx.Modbus.Reactive/MQTTnet.Rx.Modbus.Reactive.csproj" />
@@ -31,6 +32,7 @@
     <Build Project="false" />
   </Project>
   <Project Path="MQTTnet.Rx.ABPlc/MQTTnet.Rx.ABPlc.csproj" />
+  <Project Path="MQTTnet.Rx.AspNetCore/MQTTnet.Rx.AspNetCore.csproj" />
   <Project Path="MQTTnet.Rx.Client/MQTTnet.Rx.Client.csproj" />
   <Project Path="MQTTnet.Rx.Mitsubishi/MQTTnet.Rx.Mitsubishi.csproj" />
   <Project Path="MQTTnet.Rx.Modbus/MQTTnet.Rx.Modbus.csproj" />

--- a/src/eng/verify-coverage.ps1
+++ b/src/eng/verify-coverage.ps1
@@ -8,6 +8,8 @@ $ErrorActionPreference = 'Stop'
 $expectedModules = @(
     'MQTTnet.Rx.ABPlc',
     'MQTTnet.Rx.ABPlc.Reactive',
+    'MQTTnet.Rx.AspNetCore',
+    'MQTTnet.Rx.AspNetCore.Reactive',
     'MQTTnet.Rx.Client',
     'MQTTnet.Rx.Client.Reactive',
     'MQTTnet.Rx.Mitsubishi',

--- a/src/eng/verify-package-layout.py
+++ b/src/eng/verify-package-layout.py
@@ -12,6 +12,8 @@ from xml.etree import ElementTree
 EXPECTED_PACKAGE_IDS = {
     "MQTTnet.Rx.ABPlc",
     "MQTTnet.Rx.ABPlc.Reactive",
+    "MQTTnet.Rx.AspNetCore",
+    "MQTTnet.Rx.AspNetCore.Reactive",
     "MQTTnet.Rx.Client",
     "MQTTnet.Rx.Client.Reactive",
     "MQTTnet.Rx.Mitsubishi",


### PR DESCRIPTION
## What kind of change does this PR introduce?

A feature release that completes the fluent reactive MQTTnet client/server surface, adds lean and Reactive ASP.NET Core packages, expands consumer documentation, and fixes release-version resolution.

## What is the new behavior?

- `MQTTnet.Rx.Client` and `MQTTnet.Rx.Client.Reactive` expose cold `IObservable`/`IObservableAsync` wrappers for client and resilient-client operations, events, properties, lifecycle, configuration, and automatic reconnect behavior.
- `MQTTnet.Rx.Server` and `MQTTnet.Rx.Server.Reactive` expose server, client-status, session-status, enhanced-authentication, property, operation, and fluent configuration APIs.
- `MQTTnet.Rx.AspNetCore` and `MQTTnet.Rx.AspNetCore.Reactive` provide shared-source wrappers for hosting, service registration, connection contexts, packet operations, and hosted-server state.
- The README documents package selection, namespaces, ownership/cancellation semantics, all 86 public API types, and consumer-focused C# integration examples for every package family.
- BuildDeploy resolves the stable baseline before applying the selected SemVer bump and validates the staged candidate tag with repository-pinned MinVer. From the current `v4.1.0` baseline: Major = `v5.0.0`, Minor = `v4.2.0`, Patch = `v4.1.1`.

## What is the current behavior?

The solution previously lacked complete direct client/server operation and property wrappers, had no MQTTnet.AspNetCore lean/Reactive package pair, and its release workflow applied the MinVer floor after the requested bump. As a result, a selected Major release could be clamped to a Minor version (`v4.1.0`).

## Checklist

- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Release build: 0 warnings, 0 errors across net8.0, net9.0, net10.0, and net11.0 targets.
- TUnit/Microsoft.Testing.Platform: 5,632 passed, 0 failed, 0 skipped across all framework and Windows TFMs.
- Coverage: 100% line (13,108/13,108) and 100% branch (2,412/2,412) across all 20 production modules, independently verified by the repository gate and MTP coverage service.
- Packaging: all 20 expected NuGet identities packed and validated at `5.0.0`, including both new ASP.NET Core packages.
- No package publication or GitHub release is performed by this PR.