### PR TITLE
fix(ci): prevent MinVer verification casing failure

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -241,13 +241,15 @@ jobs:
         shell: bash
         env:
           EXPECTED_VERSION: ${{ steps.release-version.outputs.version }}
-          MINVER_SEMVER2: ${{ steps.minver.outputs.SemVer2 }}
-          MINVER_PACKAGE_VERSION: ${{ steps.minver.outputs.NuGetPackageVersion }}
+          # The MinVer action exports mixed-case MINVER_* names. Use a distinct
+          # prefix because Windows environment keys are case-insensitive while bash is not.
+          RELEASE_SEMVER2: ${{ steps.minver.outputs.SemVer2 }}
+          RELEASE_PACKAGE_VERSION: ${{ steps.minver.outputs.NuGetPackageVersion }}
         run: |
           set -euo pipefail
 
-          if [ "$MINVER_SEMVER2" != "$EXPECTED_VERSION" ] || [ "$MINVER_PACKAGE_VERSION" != "$EXPECTED_VERSION" ]; then
-            echo "::error::Release resolver selected ${EXPECTED_VERSION}, but MinVer returned SemVer2=${MINVER_SEMVER2} and NuGetPackageVersion=${MINVER_PACKAGE_VERSION}."
+          if [ "$RELEASE_SEMVER2" != "$EXPECTED_VERSION" ] || [ "$RELEASE_PACKAGE_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Release resolver selected ${EXPECTED_VERSION}, but MinVer returned SemVer2=${RELEASE_SEMVER2} and NuGetPackageVersion=${RELEASE_PACKAGE_VERSION}."
             exit 1
           fi
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A CI release-workflow bug fix for Windows environment-variable casing interoperability with Git Bash.

## What is the new behavior?

The MinVer verification step binds the action outputs to collision-free `RELEASE_*` variables, then continues to verify both `SemVer2` and `NuGetPackageVersion` against the requested release version. Major, Minor, and Patch version resolution is unchanged.

## What is the current behavior?

The MinVer action exports `MINVER_SemVer2`. On Windows, the verification step's `MINVER_SEMVER2` binding collides with that environment key case-insensitively, while Git Bash treats the two spellings as different. With `set -u`, the release fails on an unbound variable after correctly resolving and validating `5.0.0`.

## Checklist

- [ ] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- Failed run: https://github.com/ChrisPulman/MQTTnet.Rx/actions/runs/30900658860
- Root cause reproduced with Windows environment casing and Git Bash `set -u`.
- YAML syntax parsed successfully.
- Release matrix remains Patch `4.1.1`, Minor `4.2.0`, Major `5.0.0`.
- Pinned MinVer validation in the failed run already confirmed `5.0.0` before the casing failure.
- The failed run did not create a `v5.0.0` tag, publish NuGet packages, or create a GitHub release.
- The release workflow was not rerun while preparing this PR.
- BuildOnly validation passed: https://github.com/ChrisPulman/MQTTnet.Rx/actions/runs/30903124467
- Hosted validation: build succeeded, 5,632/5,632 TUnit tests passed, and all 20 production modules passed 100% line/branch coverage.
